### PR TITLE
Remove dependency from lxml from the main module

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ development version:
 ```python3
 from gvm.connections import UnixSocketConnection
 from gvm.protocols.latest import Gmp
-from gvm.utils import pretty_print
+from gvm.xml import pretty_print
 
 connection = UnixSocketConnection()
 gmp = Gmp(connection)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -80,3 +80,9 @@ Utils
 
 .. automodule:: gvm.utils
     :members:
+
+XML
+---
+
+.. automodule:: gvm.xml
+    :members:

--- a/gvm/utils.py
+++ b/gvm/utils.py
@@ -16,8 +16,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from lxml import etree
-
 
 def get_version_string(version):
     """Create a version string from a version tuple
@@ -34,23 +32,3 @@ def get_version_string(version):
         return ver
     else:
         return '.'.join(str(x) for x in version)
-
-
-def pretty_print(xml):
-    """Prints beautiful XML-Code
-
-    This function gets an object of list<lxml.etree._Element>
-    or directly a lxml element.
-    Print it with good readable format.
-
-    Arguments:
-        xml: List<lxml.etree.Element> or directly a lxml element
-    """
-    if isinstance(xml, list):
-        for item in xml:
-            if etree.iselement(item):
-                print(etree.tostring(item, pretty_print=True).decode('utf-8'))
-            else:
-                print(item)
-    elif etree.iselement(xml):
-        print(etree.tostring(xml, pretty_print=True).decode('utf-8'))

--- a/gvm/xml.py
+++ b/gvm/xml.py
@@ -1993,3 +1993,23 @@ class _GmpCommandFactory:
         cmd = XmlCommand('verify_scanner')
         cmd.set_attribute('scanner_id', scanner_id)
         return cmd.to_string()
+
+
+def pretty_print(xml):
+    """Prints beautiful XML-Code
+
+    This function gets an object of list<lxml.etree._Element>
+    or directly a lxml element.
+    Print it with good readable format.
+
+    Arguments:
+        xml: List<lxml.etree.Element> or directly a lxml element
+    """
+    if isinstance(xml, list):
+        for item in xml:
+            if etree.iselement(item):
+                print(etree.tostring(item, pretty_print=True).decode('utf-8'))
+            else:
+                print(item)
+    elif etree.iselement(xml):
+        print(etree.tostring(xml, pretty_print=True).decode('utf-8'))


### PR DESCRIPTION
By using get_version_string from gvm/utils.py in gvm/__init__.py I did
accidentially introduce the dependency on lxml when running the setup.py
file again. Therefore remove the lxml dependency from gvm.utils by
moving the pretty_print function to the gvm.xml module.