### PR TITLE
Update/Downgrade version

### DIFF
--- a/gvm/__init__.py
+++ b/gvm/__init__.py
@@ -20,7 +20,7 @@ Main module of gvm.
 """
 from .utils import get_version_string
 
-VERSION = (2, 0, 0, 'dev', 1)
+VERSION = (1, 0, 0, 'dev', 1)
 """
 Current Version of gvm as a tuple
 """


### PR DESCRIPTION
Don't use the same version as gvm-tools. The gvm-tools version and the
python-gvm version will diverge in future.