### PR TITLE
Add tests for simple GMP commands

### DIFF
--- a/tests/protocols/gmp/test_gmp_describe_auth.py
+++ b/tests/protocols/gmp/test_gmp_describe_auth.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.xml import _GmpCommandFactory as GmpCommandFactory
+
+
+class GMPDescribeAuthCommandTestCase(unittest.TestCase):
+    def setUp(self):
+        self.gmp = GmpCommandFactory()
+
+    def tearDown(self):
+        pass
+
+    def test_describe_auth(self):
+        cmd = self.gmp.describe_auth_command()
+
+        self.assertEqual('<describe_auth/>', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmp/test_gmp_empty_trashcan.py
+++ b/tests/protocols/gmp/test_gmp_empty_trashcan.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.xml import _GmpCommandFactory as GmpCommandFactory
+
+
+class GMPEmptyTrashcanCommandTestCase(unittest.TestCase):
+    def setUp(self):
+        self.gmp = GmpCommandFactory()
+
+    def tearDown(self):
+        pass
+
+    def test_empty_trashcan(self):
+        cmd = self.gmp.empty_trashcan_command()
+
+        self.assertEqual('<empty_trashcan/>', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmp/test_gmp_get_version.py
+++ b/tests/protocols/gmp/test_gmp_get_version.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.xml import _GmpCommandFactory as GmpCommandFactory
+
+
+class GMPGetVersionCommandTestCase(unittest.TestCase):
+    def setUp(self):
+        self.gmp = GmpCommandFactory()
+
+    def tearDown(self):
+        pass
+
+    def test_get_version(self):
+        cmd = self.gmp.get_version_command()
+
+        self.assertEqual('<get_version/>', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmp/test_gmp_sync_cert.py
+++ b/tests/protocols/gmp/test_gmp_sync_cert.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.xml import _GmpCommandFactory as GmpCommandFactory
+
+
+class GMPSyncCertCommandTestCase(unittest.TestCase):
+    def setUp(self):
+        self.gmp = GmpCommandFactory()
+
+    def tearDown(self):
+        pass
+
+    def test_sync_cert(self):
+        cmd = self.gmp.sync_cert_command()
+
+        self.assertEqual('<sync_cert/>', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmp/test_gmp_sync_config.py
+++ b/tests/protocols/gmp/test_gmp_sync_config.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.xml import _GmpCommandFactory as GmpCommandFactory
+
+
+class GMPSyncConfigCommandTestCase(unittest.TestCase):
+    def setUp(self):
+        self.gmp = GmpCommandFactory()
+
+    def tearDown(self):
+        pass
+
+    def test_sync_config(self):
+        cmd = self.gmp.sync_config_command()
+
+        self.assertEqual('<sync_config/>', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmp/test_gmp_sync_feed.py
+++ b/tests/protocols/gmp/test_gmp_sync_feed.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.xml import _GmpCommandFactory as GmpCommandFactory
+
+
+class GMPSyncFeedCommandTestCase(unittest.TestCase):
+    def setUp(self):
+        self.gmp = GmpCommandFactory()
+
+    def tearDown(self):
+        pass
+
+    def test_sync_feed(self):
+        cmd = self.gmp.sync_feed_command()
+
+        self.assertEqual('<sync_feed/>', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmp/test_gmp_sync_scap.py
+++ b/tests/protocols/gmp/test_gmp_sync_scap.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.xml import _GmpCommandFactory as GmpCommandFactory
+
+
+class GMPSyncScapCommandTestCase(unittest.TestCase):
+    def setUp(self):
+        self.gmp = GmpCommandFactory()
+
+    def tearDown(self):
+        pass
+
+    def test_sync_scap(self):
+        cmd = self.gmp.sync_scap_command()
+
+        self.assertEqual('<sync_scap/>', cmd)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit adds tests for seven 'simple' GMP commands, i.e. commands
without any attributes or subelements.