### PR TITLE
Add requirements.txt file for rtd

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,5 @@
+lxml
+paramiko
+defusedxml
+sphinx
+sphinxcontrib-napoleon


### PR DESCRIPTION
readthedocs currently doesn't support pipenv. Therefore we need a
requirements.txt file for installing the docs dependencies.