### PR TITLE
Add testcase for Unix domain socket

### DIFF
--- a/tests/connections/test_unix_socket_connection.py
+++ b/tests/connections/test_unix_socket_connection.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+import os
+import socketserver
+import tempfile
+import threading
+import uuid
+
+from gvm.connections import UnixSocketConnection, DEFAULT_TIMEOUT
+
+
+class DummyRequestHandler(socketserver.BaseRequestHandler):
+    def handle(self):
+        pass
+
+
+class ThreadedUnixStreamServer(
+    socketserver.ThreadingMixIn, socketserver.UnixStreamServer
+):
+    pass
+
+
+class UnixSocketConnectionTestCase(unittest.TestCase):
+    def setUp(self):
+        self.socketname = "%s/%s.sock" % (tempfile.gettempdir(), str(uuid.uuid4()))
+        self.sockserv = ThreadedUnixStreamServer(self.socketname, DummyRequestHandler)
+        self.server_thread = threading.Thread(target=self.sockserv.serve_forever)
+        self.server_thread.daemon = True
+        self.server_thread.start()
+
+    def tearDown(self):
+        self.sockserv.shutdown()
+        self.sockserv.server_close()
+        os.unlink(self.socketname)
+
+    def test_unix_socket_connection_connect(self):
+        self.connection = UnixSocketConnection(self.socketname, DEFAULT_TIMEOUT)
+        self.connection.connect()
+        self.connection.disconnect()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit adds an initial testcase for a connection method. The
testcase demonstrates using a threaded `UnixStreamServer` to set up an
endpoint the UnixSocketConnection class can be tested against.