### PR TITLE
Use python-gvm as package name on pypi

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Greenbone Vulnerability Management Python Library
 
 [![GitHub releases](https://img.shields.io/github/release/greenbone/python-gvm.svg)](https://github.com/greenbone/python-gvm/releases)
-[![PyPI release](https://img.shields.io/pypi/v/gvm.svg)](https://pypi.org/project/gvm/)
+[![PyPI release](https://img.shields.io/pypi/v/gvm.svg)](https://pypi.org/project/python-gvm/)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/greenbone/python-gvm/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/greenbone/python-gvm/?branch=master)
 [![code test coverage](https://codecov.io/gh/greenbone/python-gvm/branch/master/graph/badge.svg)](https://codecov.io/gh/greenbone/python-gvm)
 [![CircleCI](https://circleci.com/gh/greenbone/python-gvm/tree/master.svg?style=svg)](https://circleci.com/gh/greenbone/python-gvm/tree/master)
@@ -36,7 +36,7 @@ Python 3.5 and later is supported.
 You can install the latest stable release of python-gvm from the Python Package
 Index using [pip](https://pip.pypa.io/):
 
-    pip install gvm
+    pip install python-gvm
 
 alternatively download or clone this repository and install the latest
 development version:

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -9,7 +9,7 @@ Using pip
 You can install the latest stable release of python-gvm from the Python Package
 Index using `pip`_::
 
-    pip install gvm
+    pip install python-gvm
 
 
 Using pipenv
@@ -19,7 +19,7 @@ If you are developing an application or library that uses **python-gvm**
 internally it is often better to choose `pipenv`_ for handling your
 dependencies.::
 
-    pipenv install gvm
+    pipenv install python-gvm
 
 If you aren't using `pipenv`_ yet head over to the pipenv website for
 installation instructions.

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ with open('README.md', 'r') as f:
     long_description = f.read()
 
 setup(
-    name='gvm',
+    name='python-gvm',
     version=version,
     author='Greenbone Networks GmbH',
     author_email='info@greenbone.net',


### PR DESCRIPTION
We have agreed on using python-gvm for the package name to have a
consistent name on all "platforms".