### PR TITLE
Allow dev versions for betas

### DIFF
--- a/gvm/utils.py
+++ b/gvm/utils.py
@@ -26,9 +26,14 @@ def get_version_string(version):
     Returns:
         str: The version tuple converted into a string representation
     """
-    if len(version) > 3:
+    if len(version) > 4:
         ver = '.'.join(str(x) for x in version[:4])
         ver += str(version[4])
+
+        if len(version) > 5:
+            # support (1, 2, 3, 'beta', 2, 'dev', 1)
+            ver += '.{0}{1}'.format(str(version[5]), str(version[6]))
+
         return ver
     else:
         return '.'.join(str(x) for x in version)

--- a/tests/utils/test_get_version_string.py
+++ b/tests/utils/test_get_version_string.py
@@ -34,3 +34,7 @@ class TestGetVersionString(unittest.TestCase):
     def test_beta_version(self):
         self.assertEqual(
             get_version_string((1, 0, 1, 'beta', 1)), '1.0.1.beta1')
+
+    def test_dev_after_beta_version(self):
+        self.assertEqual(get_version_string((1, 0, 1, 'beta', 2, 'dev', 1)),
+                         '1.0.1.beta2.dev1')


### PR DESCRIPTION
After we are getting a beta we should change the version but shouldn't
use the next beta version in the repo. Therefore allow to use e.g.
beta2.dev1 after a beta1 release. beta2.dev1 > beta1 but beta2.dev1 <
beta2.