### PR TITLE
Fix closing connection after exception has been raised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # python-gvm 1.0.0 (unreleased)
 
+## gvm.protocols.base
+
+* Fix: Don't close the connection after each send/read command sequence
+  automatically. This fixes sending more then one privileged gmp command after
+  authentication.
+
 ## gvm.protocols.gmpv7
 
 * Fixed generating XML for help command

--- a/gvm/protocols/base.py
+++ b/gvm/protocols/base.py
@@ -126,7 +126,8 @@ class GvmProtocol:
         try:
             self._send(cmd)
             response = self._read()
-        finally:
+        except Exception as e:
             self.disconnect()
+            raise e
 
         return self._transform(response)


### PR DESCRIPTION
Don't close the connection after each send/read sequence. This code was
only intended to close the connection if an exception has been raised.
We need to keep the connection open for authenticated gmp requests.