### PR TITLE
Get more pep440 compliant pre release versions

### DIFF
--- a/gvm/utils.py
+++ b/gvm/utils.py
@@ -26,9 +26,13 @@ def get_version_string(version):
     Returns:
         str: The version tuple converted into a string representation
     """
-    if len(version) > 4:
-        ver = '.'.join(str(x) for x in version[:4])
-        ver += str(version[4])
+    if len(version) > 3:
+        ver = '.'.join(str(x) for x in version[:3])
+
+        if version[3] not in ('beta', 'alpha', 'rc', 'b', 'a', 'pre'):
+            ver += '.'
+
+        ver += '{0}{1}'.format(str(version[3]), str(version[4]))
 
         if len(version) > 5:
             # support (1, 2, 3, 'beta', 2, 'dev', 1)

--- a/tests/utils/test_get_version_string.py
+++ b/tests/utils/test_get_version_string.py
@@ -33,8 +33,26 @@ class TestGetVersionString(unittest.TestCase):
 
     def test_beta_version(self):
         self.assertEqual(
-            get_version_string((1, 0, 1, 'beta', 1)), '1.0.1.beta1')
+            get_version_string((1, 0, 1, 'beta', 1)), '1.0.1beta1')
 
     def test_dev_after_beta_version(self):
         self.assertEqual(get_version_string((1, 0, 1, 'beta', 2, 'dev', 1)),
-                         '1.0.1.beta2.dev1')
+                         '1.0.1beta2.dev1')
+
+    def test_pep440_pre_release_versions(self):
+        self.assertEqual(
+            get_version_string((1, 0, 1, 'beta', 1)), '1.0.1beta1')
+        self.assertEqual(
+            get_version_string((1, 0, 1, 'b', 1)), '1.0.1b1')
+        self.assertEqual(
+            get_version_string((1, 0, 1, 'alpha', 1)), '1.0.1alpha1')
+        self.assertEqual(
+            get_version_string((1, 0, 1, 'a', 1)), '1.0.1a1')
+        self.assertEqual(
+            get_version_string((1, 0, 1, 'pre', 1)), '1.0.1pre1')
+        self.assertEqual(
+            get_version_string((1, 0, 1, 'rc', 1)), '1.0.1rc1')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
PEP440 pre-releases (alpha, beta, release candidates) are put directly
behind the patch release version.

Improves https://github.com/greenbone/gvm-tools/issues/135