### PR TITLE
Improve error message if unix socket path doesn't exist

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -307,7 +307,11 @@ class UnixSocketConnection(GvmConnection):
         self._socket = socketlib.socket(
             socketlib.AF_UNIX, socketlib.SOCK_STREAM)
         self._socket.settimeout(self._timeout)
-        self._socket.connect(self.path)
+        try:
+            self._socket.connect(self.path)
+        except FileNotFoundError:
+            raise GvmError('Socket {path} does not exist'.format(
+                path=self.path)) from None
 
 
 class DebugConnection:


### PR DESCRIPTION
Don't show No such file or directory message only if the unix socket
couldn't be opened because it doesn't exist. Add an improved error
message for the user.