### PR TITLE
Send correct XML for get_settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## gvm.protocols.gmpv7
 
+* Fixed generating XML for `get_settings` command
 * Fixed generating XML for `get_credentials` command
 * Renamed create_asset method to create_host and dropped asset_type parameter. It is
   only possible to create host assets.

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -3043,7 +3043,7 @@ class Gmp(GvmProtocol):
         Returns:
             The response. See :py:meth:`send_command` for details.
         """
-        cmd = XmlCommand('get_schedules')
+        cmd = XmlCommand('get_settings')
 
         if filter:
             cmd.set_attribute('filter', filter)

--- a/tests/protocols/gmpv7/test_get_setting.py
+++ b/tests/protocols/gmpv7/test_get_setting.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import RequiredArgument
+from gvm.protocols.gmpv7 import Gmp
+
+from .. import MockConnection
+
+class GmpGetSettingTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.connection = MockConnection()
+        self.gmp = Gmp(self.connection)
+
+    def test_get_setting_simple(self):
+        self.gmp.get_setting('id')
+
+        self.connection.send.has_been_called_with(
+            '<get_settings setting_id="id"/>')
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmpv7/test_get_settings.py
+++ b/tests/protocols/gmpv7/test_get_settings.py
@@ -1,0 +1,40 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument, RequiredArgument
+from gvm.protocols.gmpv7 import Gmp
+
+from .. import MockConnection
+
+class GmpGetSettingsTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.connection = MockConnection()
+        self.gmp = Gmp(self.connection)
+
+    def test_get_settings_simple(self):
+        self.gmp.get_settings()
+
+        self.connection.send.has_been_called_with(
+            '<get_settings/>')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The `get_settings` method previously sent `get_schedules` instead of the correct GMP command.

This PR provides the unit test used for confirming this bug, the bug fix, a `CHANGELOG` entry and a unit test for the `get_setting` (singular) method.