### PR TITLE
Reduce use of contractions in text

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -16,12 +16,12 @@ Using pipenv
 ------------
 
 If you are developing an application or library that uses **python-gvm**
-internally it is often better to choose `pipenv`_ for handling your
+internally, it is often better to choose `pipenv`_ for handling your
 dependencies.::
 
     pipenv install python-gvm
 
-If you aren't using `pipenv`_ yet head over to the pipenv website for
+If you are not using `pipenv`_ yet, head over to the pipenv website for
 installation instructions.
 
 Getting the Source

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -27,7 +27,7 @@ GMP
 
 The **Greenbone Management Protocol - GMP** is the protocol implemented by the
 `Greenbone Vulnerability Manager Daemon - gvmd <https://github.com/greenbone/gvmd>`_.
-Therefore it's also used by the `Greenbone Security Assistant Daemon <https://github.com/greenbone/gsa>`_
+It is also used by the `Greenbone Security Assistant Daemon <https://github.com/greenbone/gsa>`_
 to request all of its information from **gvmd**.
 
 Make a simple request
@@ -51,7 +51,7 @@ Beginning by importing the necessary classes
 
 Afterwards we have to specify the path to the Unix domain socket in the
 filesystem. If **gvmd** is provided by a package of your distribution it should
-be ``/var/run/gvmd.sock``. If you did build **gvmd** from source and didn't set
+be ``/var/run/gvmd.sock``. If you did build **gvmd** from source and did not set
 a prefix you can use the default path by setting ``path = None``.
 
 .. code-block:: python
@@ -326,7 +326,7 @@ used:
 
 
 With this simple addition you will be able to debug ssh connection problems
-already. But what if a response didn't contain the expected data and you need to
+already. But what if a response did not contain the expected data and you need to
 know which command has been send to the server in detail? In this case it is
 necessary to wrap the actual connection in a
 :py:class:`DebugConnection <gvm.connections.DebugConnection>` class.

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -65,7 +65,7 @@ class XmlReader:
         try:
             self._parser.feed(data)
         except etree.ParseError as e:
-            raise GvmError("Can't parse xml response. Response data "
+            raise GvmError("Cannot parse XML response. Response data "
                            "read {0}".format(data), e)
 
 

--- a/gvm/protocols/base.py
+++ b/gvm/protocols/base.py
@@ -88,8 +88,9 @@ class GvmProtocol:
     def connect(self):
         """Initiates a protocol connection
 
-        Normally connect is not called directly. Either it is called automatically
-        when sending a protocol command or when using a `with statement`_.
+        Normally connect is not called directly. Either it is called
+        automatically when sending a protocol command or when using a
+        `with statement`_.
 
         .. _with statement:
             https://docs.python.org/3/reference/datamodel.html#with-statement-context-managers

--- a/gvm/protocols/base.py
+++ b/gvm/protocols/base.py
@@ -88,7 +88,7 @@ class GvmProtocol:
     def connect(self):
         """Initiates a protocol connection
 
-        Normally connect isn't called directly. Either it's called automatically
+        Normally connect is not called directly. Either it is called automatically
         when sending a protocol command or when using a `with statement`_.
 
         .. _with statement:
@@ -110,7 +110,7 @@ class GvmProtocol:
     def send_command(self, cmd):
         """Send a command to the remote server
 
-        If the class isn't connected to the server yet the connection will be
+        If the class is not connected to the server yet the connection will be
         established automatically.
 
         Arguments:

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -1735,7 +1735,7 @@ class Gmp(GvmProtocol):
 
         if hosts_ordering:
             # not sure about the possible values for hosts_orderning
-            # it seems gvmd doesn't check the param
+            # it seems gvmd does not check the param
             # gsa allows to select 'sequential', 'random' or 'reverse'
             cmd.add_element('hosts_ordering', hosts_ordering)
 
@@ -4982,7 +4982,7 @@ class Gmp(GvmProtocol):
 
         if hosts_ordering:
             # not sure about the possible values for hosts_orderning
-            # it seems gvmd doesn't check the param
+            # it seems gvmd does not check the param
             # gsa allows to select 'sequential', 'random' or 'reverse'
             cmd.add_element('hosts_ordering', hosts_ordering)
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -36,10 +36,10 @@ class CallableMock:
         assert len(self.calls) == 0, "{0} has been called.".format(self.name)
 
     def has_been_called(self):
-        assert len(self.calls) > 0, "{0} hasn't been called.".format(self.name)
+        assert len(self.calls) > 0, "{0} has not been called.".format(self.name)
 
     def has_been_called_times(self, times):
-        assert len(self.calls) == times, "{name} hasn't been called {times}" \
+        assert len(self.calls) == times, "{name} has not been called {times}" \
             " times.".format(name=self.name, times=times)
 
     def has_been_called_with(self, *args, **kwargs):
@@ -50,7 +50,7 @@ class CallableMock:
 
         # not sure if this is correct
         assert lastcall['args'] == args and lastcall['kwargs'] == kwargs, \
-            "Expected arguments {eargs} {ekwargs} of {name} don't match." \
+            "Expected arguments {eargs} {ekwargs} of {name} do not match." \
             "Received: {rargs} {rkwargs}".format(
                 name=self.name,
                 eargs=args,


### PR DESCRIPTION
Make documentation, output and code comments more consistent and easier
to read by reducing the use of contractions where appropriate.