### PR TITLE
Make sure `modify_setting` value is Base64-encoded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
   `get_preference`
 * Fixed wrong order of key and value for condition_data, event_data and
   method_data dict parameters of `modify_alert` method.
+* Ensure `modify_setting` value is Base64-encoded
 
 # python-gvm 1.0.0.beta2 (04.12.2018)
 

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -4782,7 +4782,7 @@ class Gmp(GvmProtocol):
         else:
             cmd.add_element('name', name)
 
-        cmd.add_element('value', value)
+        cmd.add_element('value', _to_base64(value))
 
         return self._send_xml_command(cmd)
 

--- a/tests/protocols/gmpv7/test_modify_setting.py
+++ b/tests/protocols/gmpv7/test_modify_setting.py
@@ -38,7 +38,7 @@ class GmpModifySettingTestCase(unittest.TestCase):
 
         self.connection.send.has_been_called_with(
             '<modify_setting setting_id="s1">'
-            '<value>bar</value>'
+            '<value>YmFy</value>'
             '</modify_setting>'
         )
 
@@ -50,7 +50,7 @@ class GmpModifySettingTestCase(unittest.TestCase):
         self.connection.send.has_been_called_with(
             '<modify_setting>'
             '<name>s1</name>'
-            '<value>bar</value>'
+            '<value>YmFy</value>'
             '</modify_setting>'
         )
 


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
The server expects the text child of a `value` element in `modify_setting` to be
Base64-encoded, failing to do so can have severe consequences like locking out
the user entirely. This PR ensures the correct encoding and adjusts the tests
accordingly.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation  N/A
