### PR TITLE
 Access `Mapping` via `collections.abc`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@
   `get_preference`
 * Fixed wrong order of key and value for condition_data, event_data and
   method_data dict parameters of `modify_alert` method.
+* Address DeprecationWarning regarding `collections` module
 
 # python-gvm 1.0.0.beta2 (04.12.2018)
 

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -1779,7 +1779,7 @@ class Gmp(GvmProtocol):
             cmd.add_element('observers', _to_comma_list(observers))
 
         if preferences is not None:
-            if not isinstance(preferences, collections.Mapping):
+            if not isinstance(preferences, collections.abc.Mapping):
                 raise InvalidArgument(
                     'preferences argument must be a dict'
                 )
@@ -5021,7 +5021,7 @@ class Gmp(GvmProtocol):
             cmd.add_element('observers', _to_comma_list(observers))
 
         if preferences is not None:
-            if not isinstance(preferences, collections.Mapping):
+            if not isinstance(preferences, collections.abc.Mapping):
                 raise InvalidArgument(
                     'preferences argument must be a dict'
                 )


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->
The Collections Abstract Base Classes were moved from the `collections`
module to the `collections.abc` module in Python 3.3. Using them via the
`collections` module was deprecated in Python 3.7 and will stop working
in Python 3.8, so the `isinstance` calls in `python-gvm` should be
adjusted accordingly.
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [X] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation N/A
