### PR TITLE
Improve handling of get_aggregates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+* Added resource_type argument to `get_aggregates` method [PR 107](https://github.com/greenbone/python-gvm/pull/107)
 * Added preferences argument to `create_task` method [PR 89](https://github.com/greenbone/python-gvm/pull/89)
 * Added validation of alive_tests argument to `create_target` method [PR 88](https://github.com/greenbone/python-gvm/pull/88)
 * Added ssh_credential_port argument to `modify_target` [PR 88](https://github.com/greenbone/python-gvm/pull/88)

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -2550,12 +2550,14 @@ class Gmp(GvmProtocol):
             The response. See :py:meth:`send_command` for details.
         """
         if not resource_type:
-            raise RequiredArgument ("get_aggregates requires resource_type
-            argument")
+            raise RequiredArgument(
+                "get_aggregates requires resource_type argument"
+            )
 
         if resource_type not in RESOURCE_TYPES:
-            raise InvalidArgument("get_aggregates requires a valid resource_type
-argument")
+            raise InvalidArgument(
+                "get_aggregates requires a valid resource_type argument"
+            )
 
         cmd = XmlCommand("get_aggregates")
 

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -2541,7 +2541,10 @@ class Gmp(GvmProtocol):
         return self._send_xml_command(cmd)
 
     def get_aggregates(self, resource_type, **kwargs):
-        """Request a list of aggregates
+        """Request aggregated information on a resource type
+
+        Additional arguments can be set via the **kwargs parameter, but are not
+        yet validated.
 
         Arguments:
            resource_type (str): The GMP resource type to gather data from

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -146,6 +146,25 @@ THREAD_TYPES = ("High", "Medium", "Low", "Alarm", "Log", "Debug")
 
 SUBJECT_TYPES = ("user", "group", "role")
 
+RESOURCE_TYPES = (
+    "alert",
+    "allinfo",
+    "cert_bund_adv",
+    "cpe",
+    "cve",
+    "dfn_cert_adv",
+    "host",
+    "note",
+    "nvt",
+    "os",
+    "ovaldef",
+    "override",
+    "report",
+    "result",
+    "task",
+    "vuln",
+)
+
 
 def _check_command_status(xml):
     """Check gmp response
@@ -2521,8 +2540,27 @@ class Gmp(GvmProtocol):
         cmd.set_attribute("details", "1")
         return self._send_xml_command(cmd)
 
-    def get_aggregates(self, **kwargs):
+    def get_aggregates(self, resource_type, **kwargs):
+        """Request a list of aggregates
+
+        Arguments:
+           resource_type (str): The GMP resource type to gather data from
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not resource_type:
+            raise RequiredArgument ("get_aggregates requires resource_type
+            argument")
+
+        if resource_type not in RESOURCE_TYPES:
+            raise InvalidArgument("get_aggregates requires a valid resource_type
+argument")
+
         cmd = XmlCommand("get_aggregates")
+
+        cmd.set_attribute("type", resource_type)
+
         cmd.set_attributes(kwargs)
         return self._send_xml_command(cmd)
 

--- a/tests/protocols/gmpv7/test_get_aggregates.py
+++ b/tests/protocols/gmpv7/test_get_aggregates.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import RequiredArgument, InvalidArgument
+from gvm.protocols.gmpv7 import Gmp
+
+from .. import MockConnection
+
+
+class GmpGetAggregatesTestCase(unittest.TestCase):
+    def setUp(self):
+        self.connection = MockConnection()
+        self.gmp = Gmp(self.connection)
+
+    def test_get_aggregates(self):
+        self.gmp.get_aggregates('alert')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="alert"/>'
+        )
+
+        self.gmp.get_aggregates('allinfo')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="allinfo"/>'
+        )
+
+        self.gmp.get_aggregates(resource_type='cert_bund_adv')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="cert_bund_adv"/>'
+        )
+
+        self.gmp.get_aggregates('cpe')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="cpe"/>'
+        )
+
+        self.gmp.get_aggregates('cve')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="cve"/>'
+        )
+
+        self.gmp.get_aggregates('dfn_cert_adv')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="dfn_cert_adv"/>'
+        )
+
+        self.gmp.get_aggregates('host')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="host"/>'
+        )
+
+        self.gmp.get_aggregates('note')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="note"/>'
+        )
+
+        self.gmp.get_aggregates('nvt')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="nvt"/>'
+        )
+
+        self.gmp.get_aggregates('os')
+
+        self.connection.send.has_been_called_with('<get_aggregates type="os"/>')
+
+        self.gmp.get_aggregates('ovaldef')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="ovaldef"/>'
+        )
+
+        self.gmp.get_aggregates('override')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="override"/>'
+        )
+
+        self.gmp.get_aggregates('report')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="report"/>'
+        )
+
+        self.gmp.get_aggregates('result')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="result"/>'
+        )
+
+        self.gmp.get_aggregates('task')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="task"/>'
+        )
+
+        self.gmp.get_aggregates('vuln')
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="vuln"/>'
+        )
+
+    def test_get_aggregates_kwargs(self):
+        self.gmp.get_aggregates('alert', group_column="family")
+
+        self.connection.send.has_been_called_with(
+            '<get_aggregates type="alert" group_column="family"/>'
+        )
+
+    def test_get_aggregates_missing_resource_type(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_aggregates(resource_type=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_aggregates(resource_type='')
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_aggregates('')
+
+    def test_get_aggregates_invalid_resource_type(self):
+        with self.assertRaises(InvalidArgument):
+            self.gmp.get_aggregates(resource_type='foo')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Make the handling of the `get_aggregates` GMP command consistent with the
handling of other GMP commands.

This includes verifying that parameters required in GMP are present and contain
a valid value.

The `get_aggregates` GMP command [allows many optional
parameters](https://docs.greenbone.net/API/GMP/gmp-8.0.html#command_get_aggregates).
The optional parameters can be passed as `kwargs` key-value pairs, but are
currently not validated.
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [x] Documentation
