### PR TITLE
Set an explicit build-backend for PEP 517 compliance

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,6 @@
 [build-system]
-requires = ["setuptools", "wheel"]
+requires = ["setuptools>=36.6.0", "wheel"]
+build-backend = "setuptools.build_meta"
 
 [tool.black]
 line-length = 80


### PR DESCRIPTION
setuptools >= 36.6.0 has a PEP 517 build backend interface.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [n/a] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [n/a] Documentation
