### PR TITLE
GMP7: Make resource_id optional when creating tags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   container task into an own method [PR 108](https://github.com/greenbone/python-gvm/pull/108)
 * Refresh the dependencies specified via the Pipfile.lock file to their latest
   versions [PR 113](https://github.com/greenbone/python-gvm/pull/113)
+* Make resource_id optional when creating tags (Gmpv7) [PR 124](https://github.com/greenbone/python-gvm/pull/124)
 
 ### Removed
 * Removed hosts_ordering argument from `modify_target` [PR 88](https://github.com/greenbone/python-gvm/pull/88)

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -1636,9 +1636,9 @@ class Gmp(GvmProtocol):
     def create_tag(
         self,
         name,
-        resource_id,
         resource_type,
         *,
+        resource_id=None,
         value=None,
         comment=None,
         active=None

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -1648,7 +1648,8 @@ class Gmp(GvmProtocol):
         Arguments:
             name (str): Name of the tag. A full tag name consisting of namespace
                 and predicate e.g. `foo:bar`.
-            resource_id (str): ID of the resource  the tag is to be attached to.
+            resource_id (str, optional): ID of the resource the tag is to be
+                attached to.
             resource_type (str): Entity type the tag is to be attached to
             value (str, optional): Value associated with the tag
             comment (str, optional): Comment for the tag
@@ -1660,14 +1661,15 @@ class Gmp(GvmProtocol):
         if not name:
             raise RequiredArgument("create_tag requires name argument")
 
-        if not resource_id:
-            raise RequiredArgument("create_tag requires resource_id argument")
-
         if not resource_type:
             raise RequiredArgument("create_tag requires resource_type argument")
 
         cmd = XmlCommand("create_tag")
         cmd.add_element("name", name)
+
+        if not resource_id:
+            resource_id = ''
+
         _xmlresource = cmd.add_element(
             "resource", attrs={"id": str(resource_id)}
         )

--- a/tests/protocols/gmpv7/test_create_tag.py
+++ b/tests/protocols/gmpv7/test_create_tag.py
@@ -41,15 +41,27 @@ class GmpCreateTagTestCase(unittest.TestCase):
             )
 
     def test_create_tag_missing_resource_id(self):
-        with self.assertRaises(RequiredArgument):
-            self.gmp.create_tag(
-                name='foo', resource_id=None, resource_type='task'
-            )
+        self.gmp.create_tag(name='foo', resource_id=None, resource_type='task')
 
-        with self.assertRaises(RequiredArgument):
-            self.gmp.create_tag(
-                name='foo', resource_id='', resource_type='task'
-            )
+        self.connection.send.has_been_called_with(
+            '<create_tag>'
+            '<name>foo</name>'
+            '<resource id="">'
+            '<type>task</type>'
+            '</resource>'
+            '</create_tag>'
+        )
+
+        self.gmp.create_tag(name='foo', resource_id='', resource_type='task')
+
+        self.connection.send.has_been_called_with(
+            '<create_tag>'
+            '<name>foo</name>'
+            '<resource id="">'
+            '<type>task</type>'
+            '</resource>'
+            '</create_tag>'
+        )
 
     def test_create_tag_missing_resource_type(self):
         with self.assertRaises(RequiredArgument):


### PR DESCRIPTION
While the protocol specification does not mention it, the implementation
does in fact allow creating tags not assigned to a specific resource,
provided an empty string is passed as `resource_id`.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [x] Documentation
