### PR TITLE
GMP8: Allow creating tags without resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Refresh the dependencies specified via the Pipfile.lock file to their latest
   versions [PR 113](https://github.com/greenbone/python-gvm/pull/113)
 * Make resource_id optional when creating tags (Gmpv7) [PR 124](https://github.com/greenbone/python-gvm/pull/124)
+* Allow creating tags without resource (Gmpv8) [PR 125](https://github.com/greenbone/python-gvm/pull/125)
 
 ### Removed
 * Removed hosts_ordering argument from `modify_target` [PR 88](https://github.com/greenbone/python-gvm/pull/88)

--- a/gvm/protocols/gmpv8.py
+++ b/gvm/protocols/gmpv8.py
@@ -412,11 +412,11 @@ class Gmp(Gmpv7):
             resource_type (str): Entity type the tag is to be attached
                 to.
             resource_filter (str, optional) Filter term to select
-                resources the tag is to be attached to. Either
-                resource_filter or resource_ids must be provided.
+                resources the tag is to be attached to. Only one of
+                resource_filter or resource_ids can be provided.
             resource_ids (list, optional): IDs of the resources the
-                tag is to be attached to. Either resource_filter or
-                resource_ids must be provided.
+                tag is to be attached to. Only one of resource_filter or
+                resource_ids can be provided.
             value (str, optional): Value associated with the tag.
             comment (str, optional): Comment for the tag.
             active (boolean, optional): Whether the tag should be
@@ -428,9 +428,9 @@ class Gmp(Gmpv7):
         if not name:
             raise RequiredArgument("create_tag requires name argument")
 
-        if not resource_filter and not resource_ids:
-            raise RequiredArgument(
-                "create_tag requires resource_filter or resource_ids argument"
+        if resource_filter and resource_ids:
+            raise InvalidArgument(
+                "create_tag accepts either resource_filter or resource_ids argument"
             )
 
         if not resource_type:

--- a/gvm/protocols/gmpv8.py
+++ b/gvm/protocols/gmpv8.py
@@ -430,7 +430,8 @@ class Gmp(Gmpv7):
 
         if resource_filter and resource_ids:
             raise InvalidArgument(
-                "create_tag accepts either resource_filter or resource_ids argument"
+                "create_tag accepts either resource_filter or resource_ids "
+                "argument"
             )
 
         if not resource_type:

--- a/tests/protocols/gmpv8/test_create_tag.py
+++ b/tests/protocols/gmpv8/test_create_tag.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from gvm.errors import RequiredArgument
+from gvm.errors import InvalidArgument, RequiredArgument
 from gvm.protocols.gmpv8 import Gmp
 
 from .. import MockConnection
@@ -41,26 +41,56 @@ class GmpCreateTagTestCase(unittest.TestCase):
             )
 
     def test_create_tag_missing_resource_filter_and_ids(self):
-        with self.assertRaises(RequiredArgument):
-            self.gmp.create_tag(
-                name='foo',
-                resource_type='task',
-                resource_filter=None,
-                resource_ids=None
-            )
+        self.gmp.create_tag(
+            name='foo',
+            resource_filter=None,
+            resource_ids=None,
+            resource_type='task',
+        )
 
-        with self.assertRaises(RequiredArgument):
-            self.gmp.create_tag(
-                name='foo',
-                resource_type='task',
-                resource_filter=None,
-                resource_ids=[]
-            )
+        self.connection.send.has_been_called_with(
+            '<create_tag>'
+            '<name>foo</name>'
+            '<resources>'
+            '<type>task</type>'
+            '</resources>'
+            '</create_tag>'
+        )
 
-        with self.assertRaises(RequiredArgument):
+        self.gmp.create_tag(
+            name='foo',
+            resource_filter=None,
+            resource_ids=[],
+            resource_type='task',
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_tag>'
+            '<name>foo</name>'
+            '<resources>'
+            '<type>task</type>'
+            '</resources>'
+            '</create_tag>'
+        )
+
+        self.gmp.create_tag(name='foo', resource_type='task')
+
+        self.connection.send.has_been_called_with(
+            '<create_tag>'
+            '<name>foo</name>'
+            '<resources>'
+            '<type>task</type>'
+            '</resources>'
+            '</create_tag>'
+        )
+
+    def test_create_tag_both_resource_filter_and_ids(self):
+        with self.assertRaises(InvalidArgument):
             self.gmp.create_tag(
                 name='foo',
-                resource_type='task'
+                resource_filter='name=foo',
+                resource_ids=['foo'],
+                resource_type='task',
             )
 
     def test_create_tag_missing_resource_type(self):
@@ -69,7 +99,7 @@ class GmpCreateTagTestCase(unittest.TestCase):
                 name='foo',
                 resource_type=None,
                 resource_filter=None,
-                resource_ids=['foo']
+                resource_ids=['foo'],
             )
 
         with self.assertRaises(RequiredArgument):
@@ -77,14 +107,12 @@ class GmpCreateTagTestCase(unittest.TestCase):
                 name='foo',
                 resource_type=None,
                 resource_filter="name=foo",
-                resource_ids=None
+                resource_ids=None,
             )
 
         with self.assertRaises(RequiredArgument):
             self.gmp.create_tag(
-                name='foo',
-                resource_type='',
-                resource_ids=['foo']
+                name='foo', resource_type='', resource_ids=['foo']
             )
 
     def test_create_tag_with_resource_filter(self):
@@ -136,7 +164,7 @@ class GmpCreateTagTestCase(unittest.TestCase):
             name='foo',
             resource_ids=['foo'],
             resource_type='task',
-            comment='bar'
+            comment='bar',
         )
 
         self.connection.send.has_been_called_with(


### PR DESCRIPTION
While the protocol specification does not mention it, the implementation
does in fact allow creating tags not assigned to a specific resource by
passing no `resource_ids` and no `resource_filter`.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [x] Documentation
