### PR TITLE
Rename constant for specific resource types

### DIFF
--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -146,7 +146,7 @@ THREAD_TYPES = ("High", "Medium", "Low", "Alarm", "Log", "Debug")
 
 SUBJECT_TYPES = ("user", "group", "role")
 
-RESOURCE_TYPES = (
+AGGREGATE_RESOURCE_TYPES = (
     "alert",
     "allinfo",
     "cert_bund_adv",
@@ -2590,7 +2590,7 @@ class Gmp(GvmProtocol):
                 "get_aggregates requires resource_type argument"
             )
 
-        if resource_type not in RESOURCE_TYPES:
+        if resource_type not in AGGREGATE_RESOURCE_TYPES:
             raise InvalidArgument(
                 "get_aggregates requires a valid resource_type argument"
             )


### PR DESCRIPTION
The constant refering to the resource types acceptable for
`get_aggregates` should make this clear in its name as it only contains
a subset of the existing resource types.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
