### PR TITLE
Add boolean "no_details" option to "get_reports()"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plural resource_ids parameter [PR 115](https://github.com/greenbone/python-gvm/pull/115)
 * Added Gmpv8 version of modify_tag with resource_action parameter,
   resource_filter parameter, plural resource_ids parameter [PR 115](https://github.com/greenbone/python-gvm/pull/115)
-* Added details argument to `get_reports` method [PR 129](https://github.com/greenbone/python-gvm/pull/129)
+* Added no_details argument to `get_reports` method [PR 129](https://github.com/greenbone/python-gvm/pull/129)
 
 ### Changed
 * Aligned ALIVE_TESTS declaration with list from GSA [PR 93](https://github.com/greenbone/python-gvm/pull/93)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plural resource_ids parameter [PR 115](https://github.com/greenbone/python-gvm/pull/115)
 * Added Gmpv8 version of modify_tag with resource_action parameter,
   resource_filter parameter, plural resource_ids parameter [PR 115](https://github.com/greenbone/python-gvm/pull/115)
+* Added details argument to `get_reports` method [PR 129](https://github.com/greenbone/python-gvm/pull/129)
 
 ### Changed
 * Aligned ALIVE_TESTS declaration with list from GSA [PR 93](https://github.com/greenbone/python-gvm/pull/93)

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -3372,7 +3372,8 @@ class Gmp(GvmProtocol):
         filter=None,
         filter_id=None,
         note_details=None,
-        override_details=None
+        override_details=None,
+        details=None
     ):
         """Request a list of reports
 
@@ -3384,6 +3385,7 @@ class Gmp(GvmProtocol):
                 include note details
             override_details (boolean, optional): If overrides are included,
                 whether to include override details
+            details (boolean, optional): Whether to exclude results
 
         Returns:
             The response. See :py:meth:`send_command` for details.
@@ -3401,6 +3403,9 @@ class Gmp(GvmProtocol):
 
         if not override_details is None:
             cmd.set_attribute("override_details", _to_bool(override_details))
+
+        if not details is None:
+            cmd.set_attribute("details", _to_bool(details))
 
         cmd.set_attribute("ignore_pagination", "1")
 

--- a/gvm/protocols/gmpv7.py
+++ b/gvm/protocols/gmpv7.py
@@ -3373,7 +3373,7 @@ class Gmp(GvmProtocol):
         filter_id=None,
         note_details=None,
         override_details=None,
-        details=None
+        no_details=None
     ):
         """Request a list of reports
 
@@ -3385,7 +3385,7 @@ class Gmp(GvmProtocol):
                 include note details
             override_details (boolean, optional): If overrides are included,
                 whether to include override details
-            details (boolean, optional): Whether to exclude results
+            no_details (boolean, optional): Whether to exclude results
 
         Returns:
             The response. See :py:meth:`send_command` for details.
@@ -3404,8 +3404,8 @@ class Gmp(GvmProtocol):
         if not override_details is None:
             cmd.set_attribute("override_details", _to_bool(override_details))
 
-        if not details is None:
-            cmd.set_attribute("details", _to_bool(details))
+        if not no_details is None:
+            cmd.set_attribute("details", _to_bool(not no_details))
 
         cmd.set_attribute("ignore_pagination", "1")
 

--- a/tests/protocols/gmpv7/test_get_reports.py
+++ b/tests/protocols/gmpv7/test_get_reports.py
@@ -77,6 +77,20 @@ class GmpGetReportsTestCase(unittest.TestCase):
             '<get_reports override_details="1" ignore_pagination="1"/>'
         )
 
+    def test_get_reports_without_details(self):
+        self.gmp.get_reports(details=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_reports details="0" ignore_pagination="1"/>'
+        )
+
+    def test_get_reports_with_details(self):
+        self.gmp.get_reports(details=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_reports details="1" ignore_pagination="1"/>'
+        )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/protocols/gmpv7/test_get_reports.py
+++ b/tests/protocols/gmpv7/test_get_reports.py
@@ -77,18 +77,18 @@ class GmpGetReportsTestCase(unittest.TestCase):
             '<get_reports override_details="1" ignore_pagination="1"/>'
         )
 
-    def test_get_reports_without_details(self):
-        self.gmp.get_reports(details=False)
-
-        self.connection.send.has_been_called_with(
-            '<get_reports details="0" ignore_pagination="1"/>'
-        )
-
     def test_get_reports_with_details(self):
-        self.gmp.get_reports(details=True)
+        self.gmp.get_reports(no_details=False)
 
         self.connection.send.has_been_called_with(
             '<get_reports details="1" ignore_pagination="1"/>'
+        )
+
+    def test_get_reports_without_details(self):
+        self.gmp.get_reports(no_details=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_reports details="0" ignore_pagination="1"/>'
         )
 
 


### PR DESCRIPTION
GMP v7 and up support the undocumented boolean parameter "details", which can be set to "0" to suppress results. As of GMP v8 this is the preferred way of getting a list of reports related to a task, since the reports are no longer included in get_tasks().

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

This closes https://github.com/greenbone/python-gvm/issues/128.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [x] Documentation
