### PR TITLE
Add 'SMB' as allowed 'AlertMethod'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 ### Fixed
+* Re-added `SMB` as an allowed `AlertMethod` for SecInfo events
+  [PR 145](https://github.com/greenbone/python-gvm/pull/145)
 
 ### Removed
 

--- a/gvm/protocols/gmpv7/__init__.py
+++ b/gvm/protocols/gmpv7/__init__.py
@@ -139,6 +139,7 @@ def _check_event(
         if method not in (
             AlertMethod.SCP,
             AlertMethod.SEND,
+            AlertMethod.SMB,
             AlertMethod.SNMP,
             AlertMethod.SYSLOG,
             AlertMethod.EMAIL,


### PR DESCRIPTION
Add the `AlertMethod` `SMB` to the list of `method`s valid for the
`AlertEvent`s `NEW_SECINFO_ARRIVED` and `UPDATED_SECINFO_ARRIVED` as
it is accepted by `gvmd`.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation N/A
