### PR TITLE
16kB buffer decreases fetch time of large reports

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -34,7 +34,7 @@ from gvm.errors import GvmError
 
 logger = logging.getLogger(__name__)
 
-BUF_SIZE = 1024
+BUF_SIZE = 16 * 1024
 DEFAULT_READ_TIMEOUT = 60  # in seconds
 DEFAULT_TIMEOUT = 60  # in seconds
 DEFAULT_GVM_PORT = 9390


### PR DESCRIPTION
If we increase the buffer, bigger reports could be fetched much faster. A 35 MB report retrieved by get_reports function took on my machine (I did several tries) between 44 and 108 seconds. I think the 16kB buffer gives the best performance and just a slight increase in memory footprint:

Buffer	Time
1*1024	108 seconds
2*1024	106 seconds
8*1024	 Between 66 and 68 seconds
16*1024	 Between 43 and 44 seconds
32*1024	 46..49
64*1024	 53..47
128*1024 55 seconds

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
