### PR TITLE
Correct type hint for 'get_time_unit_from_string'

### DIFF
--- a/gvm/protocols/gmpv7/types.py
+++ b/gvm/protocols/gmpv7/types.py
@@ -696,9 +696,7 @@ class TimeUnit(Enum):
     DECADE = "decade"
 
 
-def get_time_unit_from_string(
-    time_unit: Optional[str]
-) -> Optional[SeverityLevel]:
+def get_time_unit_from_string(time_unit: Optional[str]) -> Optional[TimeUnit]:
     """ Convert a time unit string into a TimeUnit instance """
     if not time_unit:
         return None


### PR DESCRIPTION
Found with `mypy`, `get_time_unit_from_string` does indeed return an
optional `TimeUnit` and not a `SeverityLevel`.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
