### PR TITLE
Correct type hints for '_to_base64'

### DIFF
--- a/gvm/protocols/gmpv7/__init__.py
+++ b/gvm/protocols/gmpv7/__init__.py
@@ -80,7 +80,7 @@ def _to_bool(value: bool) -> str:
     return "1" if value else "0"
 
 
-def _to_base64(value: bytes) -> str:
+def _to_base64(value: str) -> bytes:
     return base64.b64encode(value.encode("utf-8"))
 
 


### PR DESCRIPTION
Note that this means in consequence that the second argument for the
`add_element` calls using `_to_base64` is `bytes` instead of the hinted
`str`.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
