### PR TITLE
Avoid calling 'send' on unconnected connection

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -107,6 +107,9 @@ class GvmConnection(XmlReader):
             data: Data to be send to the server. Either utf-8 encoded string or
                 bytes.
         """
+        if self._socket is None:
+            raise GvmError("Socket is not connected")
+
         if isinstance(data, str):
             self._socket.sendall(data.encode())
         else:

--- a/tests/connections/test_unix_socket_connection.py
+++ b/tests/connections/test_unix_socket_connection.py
@@ -25,6 +25,7 @@ import threading
 import uuid
 
 from gvm.connections import UnixSocketConnection, DEFAULT_TIMEOUT
+from gvm.errors import GvmError
 
 
 class DummyRequestHandler(socketserver.BaseRequestHandler):
@@ -86,6 +87,13 @@ class UnixSocketConnectionTestCase(unittest.TestCase):
         self.connection.send("<gmp/>")
         self.connection.read()
         self.connection.disconnect()
+
+    def test_unix_socket_send_unconnected_socket(self):
+        self.connection = UnixSocketConnection(
+            path=self.socketname, timeout=DEFAULT_TIMEOUT
+        )
+        with self.assertRaises(GvmError):
+            self.connection.send("<gmp>/")
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Trying to `send` to a `connection` before `connect` has been called should
result in an error.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
