### PR TITLE
Remove deprecated defusedxml.lxml

### DIFF
--- a/gvm/xml.py
+++ b/gvm/xml.py
@@ -18,8 +18,6 @@
 
 from typing import Optional
 
-import defusedxml.lxml as secET
-
 from defusedxml import DefusedXmlException
 from lxml import etree
 
@@ -62,7 +60,7 @@ class XmlCommandElement:
 
     def append_xml_str(self, xml_text: str):
         """Append a xml element in string format."""
-        node = secET.fromstring(xml_text)
+        node = etree.fromstring(xml_text)
         self._element.append(node)
 
     def to_string(self) -> str:
@@ -100,7 +98,7 @@ def pretty_print(xml):
     elif etree.iselement(xml):
         print(etree.tostring(xml, pretty_print=True).decode("utf-8"))
     elif isinstance(xml, str):
-        tree = secET.fromstring(xml)
+        tree = etree.fromstring(xml)
         print(etree.tostring(tree, pretty_print=True).decode("utf-8"))
 
 
@@ -118,6 +116,6 @@ def validate_xml_string(xml_string: str):
 
     """
     try:
-        secET.fromstring(xml_string)
+        etree.fromstring(xml_string)
     except (DefusedXmlException, etree.LxmlError) as e:
         raise GvmError("Invalid XML", e) from e


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

pytest pointed out that defusedxml.lxml is deprecated. Referring to [this](https://github.com/tiran/defusedxml/issues/38) and some other discussions lxml should be safe against xml bomb attacks itself.

Tests passed this changes.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation