### PR TITLE
Changed the default gvmd socket path

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -38,7 +38,7 @@ BUF_SIZE = 16 * 1024
 DEFAULT_READ_TIMEOUT = 60  # in seconds
 DEFAULT_TIMEOUT = 60  # in seconds
 DEFAULT_GVM_PORT = 9390
-DEFAULT_UNIX_SOCKET_PATH = "/usr/local/var/run/gvmd.sock"
+DEFAULT_UNIX_SOCKET_PATH = "/var/run/gvmd.sock"
 MAX_SSH_DATA_LENGTH = 4095
 
 


### PR DESCRIPTION
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

This should be the path to the unix socket in normal circumstances. But it must not be correct (as gvmd uses the CMAKE_INSTALL_PREFIX in the path to the socket ...)

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
