### PR TITLE
Improve gmpv9

### DIFF
--- a/gvm/protocols/gmpv9/__init__.py
+++ b/gvm/protocols/gmpv9/__init__.py
@@ -216,11 +216,11 @@ class Gmp(Gmpv8):
         """Create a new TLS certificate
 
         Arguments:
-            comment: Comment for the TLS certificate.
             name: Name of the TLS certificate, defaulting to the MD5
                 fingerprint.
-            trust: Whether the certificate is trusted.
             certificate: The Base64 encoded certificate data (x.509 DER or PEM).
+            comment: Comment for the TLS certificate.
+            trust: Whether the certificate is trusted.
 
         Returns:
             The response. See :py:meth:`send_command` for details.
@@ -260,6 +260,8 @@ class Gmp(Gmpv8):
         Arguments:
             filter: Filter term to use for the query
             filter_id: UUID of an existing filter to use for the query
+            include_certificate_data: Wether to include the certifacte data in
+                the response
 
         Returns:
             The response. See :py:meth:`send_command` for details.

--- a/gvm/protocols/gmpv9/__init__.py
+++ b/gvm/protocols/gmpv9/__init__.py
@@ -41,6 +41,8 @@ from . import types
 from .types import *
 from .types import _UsageType as UsageType
 
+_EMPTY_POLICY_ID = '085569ce-73ed-11df-83c3-002264764cea'
+
 PROTOCOL_VERSION = (9,)
 
 
@@ -129,16 +131,19 @@ class Gmp(Gmpv8):
             function=self.create_config.__name__,
         )
 
-    def create_policy(self, policy_id: str, name: str) -> Any:
+    def create_policy(self, name: str, *, policy_id: str = None) -> Any:
         """Create a new policy config
 
         Arguments:
-            policy_id: UUID of the existing policy config
-            name: Name of the new scan config
+            name: Name of the new policy
+            policy_id: UUID of an existing policy as base. By default the empty
+                policy is used.
 
         Returns:
             The response. See :py:meth:`send_command` for details.
         """
+        if policy_id is None:
+            policy_id = _EMPTY_POLICY_ID
         return self.__create_config(
             config_id=policy_id,
             name=name,

--- a/gvm/protocols/gmpv9/__init__.py
+++ b/gvm/protocols/gmpv9/__init__.py
@@ -60,7 +60,7 @@ class Gmp(Gmpv8):
     def create_audit(
         self,
         name: str,
-        audit_id: str,
+        policy_id: str,
         target_id: str,
         scanner_id: str,
         *,
@@ -77,7 +77,7 @@ class Gmp(Gmpv8):
 
         Arguments:
             name: Name of the new audit
-            audit_id: UUID of scan config to use by the audit
+            policy_id: UUID of policy to use by the audit
             target_id: UUID of target to be scanned
             scanner_id: UUID of scanner to use for scanning the target
             comment: Comment for the audit
@@ -97,10 +97,10 @@ class Gmp(Gmpv8):
 
         return self.__create_task(
             name=name,
-            config_id=audit_id,
+            config_id=policy_id,
             target_id=target_id,
             scanner_id=scanner_id,
-            usage_type=UsageType.AUDIT,  # pylint: disable=W0212
+            usage_type=UsageType.AUDIT,
             function=self.create_audit.__name__,
             alterable=alterable,
             hosts_ordering=hosts_ordering,

--- a/tests/protocols/gmpv9/test_create_audit.py
+++ b/tests/protocols/gmpv9/test_create_audit.py
@@ -31,7 +31,7 @@ from . import Gmpv9TestCase
 class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
     def test_create_task(self):
         self.gmp.create_audit(
-            name='foo', audit_id='c1', target_id='t1', scanner_id='s1'
+            name='foo', policy_id='c1', target_id='t1', scanner_id='s1'
         )
 
         self.connection.send.has_been_called_with(
@@ -47,51 +47,51 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
     def test_create_audit_missing_name(self):
         with self.assertRaises(RequiredArgument):
             self.gmp.create_audit(
-                name=None, audit_id='c1', target_id='t1', scanner_id='s1'
+                name=None, policy_id='c1', target_id='t1', scanner_id='s1'
             )
 
         with self.assertRaises(RequiredArgument):
             self.gmp.create_audit(
-                name='', audit_id='c1', target_id='t1', scanner_id='s1'
+                name='', policy_id='c1', target_id='t1', scanner_id='s1'
             )
 
-    def test_create_audit_missing_audit_id(self):
+    def test_create_audit_missing_policy_id(self):
         with self.assertRaises(RequiredArgument):
             self.gmp.create_audit(
-                name='foo', audit_id=None, target_id='t1', scanner_id='s1'
+                name='foo', policy_id=None, target_id='t1', scanner_id='s1'
             )
 
         with self.assertRaises(RequiredArgument):
             self.gmp.create_audit(
-                name='foo', audit_id='', target_id='t1', scanner_id='s1'
+                name='foo', policy_id='', target_id='t1', scanner_id='s1'
             )
 
     def test_create_audit_missing_target_id(self):
         with self.assertRaises(RequiredArgument):
             self.gmp.create_audit(
-                name='foo', audit_id='c1', target_id=None, scanner_id='s1'
+                name='foo', policy_id='c1', target_id=None, scanner_id='s1'
             )
 
         with self.assertRaises(RequiredArgument):
             self.gmp.create_audit(
-                name='foo', audit_id='c1', target_id='', scanner_id='s1'
+                name='foo', policy_id='c1', target_id='', scanner_id='s1'
             )
 
     def test_create_audit_missing_scanner_id(self):
         with self.assertRaises(RequiredArgument):
             self.gmp.create_audit(
-                name='foo', audit_id='c1', target_id='t1', scanner_id=None
+                name='foo', policy_id='c1', target_id='t1', scanner_id=None
             )
 
         with self.assertRaises(RequiredArgument):
             self.gmp.create_audit(
-                name='foo', audit_id='c1', target_id='t1', scanner_id=''
+                name='foo', policy_id='c1', target_id='t1', scanner_id=''
             )
 
     def test_create_audit_with_comment(self):
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             comment='bar',
@@ -115,7 +115,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
 
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id='t1',
                 scanner_id='s1',
                 alert_ids='a1',  # will be removed in future
@@ -137,7 +137,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
 
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             alert_ids=['a1'],
@@ -157,7 +157,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
     def test_create_audit_multiple_alerts(self):
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             alert_ids=['a1', 'a2', 'a3'],
@@ -179,7 +179,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
     def test_create_audit_with_alterable(self):
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             alterable=True,
@@ -198,7 +198,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
 
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             alterable=False,
@@ -218,7 +218,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
     def test_create_audit_with_hosts_ordering(self):
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             hosts_ordering=HostsOrdering.REVERSE,
@@ -239,7 +239,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
         with self.assertRaises(InvalidArgument):
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id='t1',
                 scanner_id='s1',
                 hosts_ordering='foo',
@@ -248,7 +248,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
     def test_create_audit_with_schedule(self):
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             schedule_id='s1',
@@ -268,7 +268,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
     def test_create_audit_with_schedule_and_schedule_periods(self):
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             schedule_id='s1',
@@ -289,7 +289,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
 
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             schedule_id='s1',
@@ -312,7 +312,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
         with self.assertRaises(InvalidArgument):
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id='t1',
                 scanner_id='s1',
                 schedule_id='s1',
@@ -322,7 +322,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
         with self.assertRaises(InvalidArgument):
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id='t1',
                 scanner_id='s1',
                 schedule_id='s1',
@@ -332,7 +332,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
     def test_create_audit_with_observers(self):
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             observers=['u1', 'u2'],
@@ -353,7 +353,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
         with self.assertRaises(InvalidArgument):
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id='t1',
                 scanner_id='s1',
                 observers='',
@@ -362,7 +362,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
         with self.assertRaises(InvalidArgument):
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id='t1',
                 scanner_id='s1',
                 observers='foo',
@@ -371,7 +371,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
     def test_create_audit_with_preferences(self):
         self.gmp.create_audit(
             name='foo',
-            audit_id='c1',
+            policy_id='c1',
             target_id='t1',
             scanner_id='s1',
             preferences=OrderedDict([('foo', 'bar'), ('lorem', 'ipsum')]),
@@ -401,7 +401,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
         with self.assertRaises(InvalidArgument):
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id='t1',
                 scanner_id='s1',
                 preferences='',
@@ -410,7 +410,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
         with self.assertRaises(InvalidArgument):
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id='t1',
                 scanner_id='s1',
                 preferences=['foo', 'bar'],
@@ -420,7 +420,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
         with self.assertRaises(InvalidArgument):
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id='0',
                 scanner_id='s1',
                 observers='',
@@ -430,7 +430,7 @@ class GmpCreateAuditCommandTestCase(Gmpv9TestCase):
         with self.assertRaises(RequiredArgument):
             self.gmp.create_audit(
                 name='foo',
-                audit_id='c1',
+                policy_id='c1',
                 target_id=0,
                 scanner_id='s1',
                 observers='',

--- a/tests/protocols/gmpv9/test_create_policy.py
+++ b/tests/protocols/gmpv9/test_create_policy.py
@@ -25,22 +25,26 @@ from . import Gmpv9TestCase
 
 class GmpCreatePolicyTestCase(Gmpv9TestCase):
     def test_create_policy(self):
-        self.gmp.create_policy('a1', 'foo')
+        self.gmp.create_policy('foo')
 
         self.connection.send.has_been_called_with(
             '<create_config>'
-            '<copy>a1</copy>'
+            '<copy>085569ce-73ed-11df-83c3-002264764cea</copy>'
             '<name>foo</name>'
             '<usage_type>policy</usage_type>'
             '</create_config>'
         )
 
-    def test_missing_policy_id(self):
-        with self.assertRaises(RequiredArgument):
-            self.gmp.create_policy(policy_id='', name='foo')
+    def test_create_with_policy_id(self):
+        self.gmp.create_policy('foo', policy_id='p1')
 
-        with self.assertRaises(RequiredArgument):
-            self.gmp.create_policy(policy_id=None, name='foo')
+        self.connection.send.has_been_called_with(
+            '<create_config>'
+            '<copy>p1</copy>'
+            '<name>foo</name>'
+            '<usage_type>policy</usage_type>'
+            '</create_config>'
+        )
 
     def test_missing_name(self):
         with self.assertRaises(RequiredArgument):


### PR DESCRIPTION
* Use policy_id instead of audit_id for create_audit
* Make policy_id optional for create_policy
* Update docstrings

**Checklist**:

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [x] Documentation
