### PR TITLE
Don't shutdown half TLS connection after sending.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Use Gmpv9 in gvm.protocols.latest module [#165](https://github.com/greenbone/python-gvm/pull/165)
 * Added type `TLS_CERTIFICATE` to `EntityType` and `FilterType` [#157](https://github.com/greenbone/python-gvm/pull/157)
 * Changed the `DEFAULT_UNIX_SOCKET_PATH` [#119](https://github.com/greenbone/python-gvm/pull/162)
+* ospv1.py: Don't half shutdown the TLS socket. [#180](https://github.com/greenbone/python-gvm/pull/180)
 
 ### Deprecated
 * Mark make_unique argument of create_target Gmpv8 as deprecated and ignore it.

--- a/gvm/protocols/ospv1.py
+++ b/gvm/protocols/ospv1.py
@@ -92,12 +92,6 @@ class Osp(GvmProtocol):
         self.disconnect()
         return data
 
-    def _send(self, data):
-        # OSP is stateless. Therefore we can shutdown the socket if we are done
-        # with sending
-        super()._send(data)
-        self._connection.finish_send()
-
     def get_version(self):
         """Get the version of the OSPD server which is connected to."""
         cmd = XmlCommand("get_version")


### PR DESCRIPTION
The underlying TLS layer still needs to send this close_notify packet before
really shutting down the communication, otherwise, it will be considered as
a truncation attack.

https://tools.ietf.org/html/rfc2246#section-7.2.1
https://stackoverflow.com/questions/6424998/properly-closing-sslsocket

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
