### PR TITLE
Fix value of EntityType AGENT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 ### Fixed
+* Fixed value of `EntityType.AGENT` enum [#190](https://github.com/greenbone/python-gvm/pull/190)
 
 [Unreleased]: https://github.com/greenbone/python-gvm/compare/v1.1.0...master
 

--- a/gvm/protocols/gmpv7/types.py
+++ b/gvm/protocols/gmpv7/types.py
@@ -308,7 +308,7 @@ def get_credential_type_from_string(
 class EntityType(Enum):
     """ Enum for entity types """
 
-    AGENT = "note"
+    AGENT = "agent"
     ALERT = "alert"
     ASSET = "asset"
     CERT_BUND_ADV = "cert_bund_adv"

--- a/gvm/protocols/gmpv8/types.py
+++ b/gvm/protocols/gmpv8/types.py
@@ -102,7 +102,7 @@ __all__ = [
 class EntityType(Enum):
     """ Enum for entity types """
 
-    AGENT = "note"
+    AGENT = "agent"
     ALERT = "alert"
     ASSET = "asset"
     CERT_BUND_ADV = "cert_bund_adv"

--- a/gvm/protocols/gmpv9/types.py
+++ b/gvm/protocols/gmpv9/types.py
@@ -106,7 +106,7 @@ __all__ = [
 class EntityType(Enum):
     """ Enum for entity types """
 
-    AGENT = "note"
+    AGENT = "agent"
     ALERT = "alert"
     ASSET = "asset"
     CERT_BUND_ADV = "cert_bund_adv"


### PR DESCRIPTION
The value of `EntityType.AGENT` in the various GMP protocols was `note`, but should be `agent`.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation N/A
