### PR TITLE
Improve readability of conditionals

### DIFF
--- a/gvm/protocols/gmpv7/__init__.py
+++ b/gvm/protocols/gmpv7/__init__.py
@@ -407,21 +407,21 @@ class Gmp(GvmProtocol):
 
         conditions = cmd.add_element("condition", condition.value)
 
-        if not condition_data is None:
+        if condition_data is not None:
             for key, value in condition_data.items():
                 _data = conditions.add_element("data", value)
                 _data.add_element("name", key)
 
         events = cmd.add_element("event", event.value)
 
-        if not event_data is None:
+        if event_data is not None:
             for key, value in event_data.items():
                 _data = events.add_element("data", value)
                 _data.add_element("name", key)
 
         methods = cmd.add_element("method", method.value)
 
-        if not method_data is None:
+        if method_data is not None:
             for key, value in method_data.items():
                 _data = methods.add_element("data", value)
                 _data.add_element("name", key)
@@ -917,7 +917,7 @@ class Gmp(GvmProtocol):
         cmd.add_element("text", text)
         cmd.add_element("nvt", attrs={"oid": nvt_oid})
 
-        if not seconds_active is None:
+        if seconds_active is not None:
             cmd.add_element("active", str(seconds_active))
 
         if hosts:
@@ -1014,7 +1014,7 @@ class Gmp(GvmProtocol):
         cmd.add_element("text", text)
         cmd.add_element("nvt", attrs={"oid": nvt_oid})
 
-        if not seconds_active is None:
+        if seconds_active is not None:
             cmd.add_element("active", str(seconds_active))
 
         if hosts:
@@ -1328,7 +1328,7 @@ class Gmp(GvmProtocol):
                 argument='task_id or task_name',
             )
 
-        if not in_assets is None:
+        if in_assets is not None:
             cmd.add_element("in_assets", _to_bool(in_assets))
 
         try:
@@ -1753,7 +1753,7 @@ class Gmp(GvmProtocol):
         if value:
             cmd.add_element("value", value)
 
-        if not active is None:
+        if active is not None:
             if active:
                 cmd.add_element("active", "1")
             else:
@@ -1878,12 +1878,12 @@ class Gmp(GvmProtocol):
 
             cmd.add_element("alive_tests", alive_test.value)
 
-        if not reverse_lookup_only is None:
+        if reverse_lookup_only is not None:
             cmd.add_element(
                 "reverse_lookup_only", _to_bool(reverse_lookup_only)
             )
 
-        if not reverse_lookup_unify is None:
+        if reverse_lookup_unify is not None:
             cmd.add_element(
                 "reverse_lookup_unify", _to_bool(reverse_lookup_unify)
             )
@@ -1986,7 +1986,7 @@ class Gmp(GvmProtocol):
         if comment:
             cmd.add_element("comment", comment)
 
-        if not alterable is None:
+        if alterable is not None:
             cmd.add_element("alterable", _to_bool(alterable))
 
         if hosts_ordering:
@@ -2668,14 +2668,14 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
         if format:
-            if not format in ("installer", "howto_install", "howto_use"):
+            if format not in ("installer", "howto_install", "howto_use"):
                 raise InvalidArgument(
                     "installer argument needs to be one of installer, "
                     "howto_install or howto_use"
@@ -2759,10 +2759,10 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not tasks is None:
+        if tasks is not None:
             cmd.set_attribute("tasks", _to_bool(tasks))
 
         return self._send_xml_command(cmd)
@@ -2871,13 +2871,13 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not scanners is None:
+        if scanners is not None:
             cmd.set_attribute("scanners", _to_bool(scanners))
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not targets is None:
+        if targets is not None:
             cmd.set_attribute("targets", _to_bool(targets))
 
         return self._send_xml_command(cmd)
@@ -2948,19 +2948,19 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
-        if not families is None:
+        if families is not None:
             cmd.set_attribute("families", _to_bool(families))
 
-        if not preferences is None:
+        if preferences is not None:
             cmd.set_attribute("preferences", _to_bool(preferences))
 
-        if not tasks is None:
+        if tasks is not None:
             cmd.set_attribute("tasks", _to_bool(tasks))
 
         return self._send_xml_command(cmd)
@@ -3043,10 +3043,10 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not alerts is None:
+        if alerts is not None:
             cmd.set_attribute("alerts", _to_bool(alerts))
 
         return self._send_xml_command(cmd)
@@ -3090,7 +3090,7 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
         return self._send_xml_command(cmd)
@@ -3157,7 +3157,7 @@ class Gmp(GvmProtocol):
         if name:
             cmd.set_attribute("name", name)
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
         return self._send_xml_command(cmd)
@@ -3222,10 +3222,10 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
-        if not result is None:
+        if result is not None:
             cmd.set_attribute("result", _to_bool(result))
 
         return self._send_xml_command(cmd)
@@ -3283,16 +3283,16 @@ class Gmp(GvmProtocol):
         """
         cmd = XmlCommand("get_nvts")
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
-        if not preferences is None:
+        if preferences is not None:
             cmd.set_attribute("preferences", _to_bool(preferences))
 
-        if not preference_count is None:
+        if preference_count is not None:
             cmd.set_attribute("preference_count", _to_bool(preference_count))
 
-        if not timeout is None:
+        if timeout is not None:
             cmd.set_attribute("timeout", _to_bool(timeout))
 
         if config_id:
@@ -3372,10 +3372,10 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
-        if not result is None:
+        if result is not None:
             cmd.set_attribute("result", _to_bool(result))
 
         return self._send_xml_command(cmd)
@@ -3422,7 +3422,7 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
         return self._send_xml_command(cmd)
@@ -3470,13 +3470,13 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
-        if not targets is None:
+        if targets is not None:
             cmd.set_attribute("targets", _to_bool(targets))
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
         return self._send_xml_command(cmd)
@@ -3580,13 +3580,13 @@ class Gmp(GvmProtocol):
         if filter_id:
             cmd.set_attribute("report_filt_id", filter_id)
 
-        if not note_details is None:
+        if note_details is not None:
             cmd.set_attribute("note_details", _to_bool(note_details))
 
-        if not override_details is None:
+        if override_details is not None:
             cmd.set_attribute("override_details", _to_bool(override_details))
 
-        if not no_details is None:
+        if no_details is not None:
             cmd.set_attribute("details", _to_bool(not no_details))
 
         cmd.set_attribute("ignore_pagination", "1")
@@ -3670,16 +3670,16 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
-        if not alerts is None:
+        if alerts is not None:
             cmd.set_attribute("alerts", _to_bool(alerts))
 
-        if not params is None:
+        if params is not None:
             cmd.set_attribute("params", _to_bool(params))
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
         return self._send_xml_command(cmd)
@@ -3737,13 +3737,13 @@ class Gmp(GvmProtocol):
         if task_id:
             cmd.set_attribute("task_id", task_id)
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
-        if not note_details is None:
+        if note_details is not None:
             cmd.set_attribute("note_details", _to_bool(note_details))
 
-        if not override_details is None:
+        if override_details is not None:
             cmd.set_attribute("override_details", _to_bool(override_details))
 
         return self._send_xml_command(cmd)
@@ -3790,7 +3790,7 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
         return self._send_xml_command(cmd)
@@ -3837,10 +3837,10 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
         return self._send_xml_command(cmd)
@@ -3889,10 +3889,10 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not tasks is None:
+        if tasks is not None:
             cmd.set_attribute("tasks", _to_bool(tasks))
 
         return self._send_xml_command(cmd)
@@ -3980,7 +3980,7 @@ class Gmp(GvmProtocol):
         if name:
             cmd.set_attribute("name", name)
 
-        if not duration is None:
+        if duration is not None:
             if not isinstance(duration, numbers.Integral):
                 raise InvalidArgument("duration needs to be an integer number")
 
@@ -3992,7 +3992,7 @@ class Gmp(GvmProtocol):
         if end_time:
             cmd.set_attribute("end_time", str(end_time))
 
-        if not brief is None:
+        if brief is not None:
             cmd.set_attribute("brief", _to_bool(brief))
 
         if slave_id:
@@ -4023,10 +4023,10 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not names_only is None:
+        if names_only is not None:
             cmd.set_attribute("names_only", _to_bool(names_only))
 
         return self._send_xml_command(cmd)
@@ -4072,10 +4072,10 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not tasks is None:
+        if tasks is not None:
             cmd.set_attribute("tasks", _to_bool(tasks))
 
         return self._send_xml_command(cmd)
@@ -4124,13 +4124,13 @@ class Gmp(GvmProtocol):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
-        if not details is None:
+        if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 
-        if not schedules_only is None:
+        if schedules_only is not None:
             cmd.set_attribute("schedules_only", _to_bool(schedules_only))
 
         return self._send_xml_command(cmd)
@@ -4334,7 +4334,7 @@ class Gmp(GvmProtocol):
 
             conditions = cmd.add_element("condition", condition.value)
 
-            if not condition_data is None:
+            if condition_data is not None:
                 for key, value in condition_data.items():
                     _data = conditions.add_element("data", value)
                     _data.add_element("name", key)
@@ -4349,7 +4349,7 @@ class Gmp(GvmProtocol):
 
             methods = cmd.add_element("method", method.value)
 
-            if not method_data is None:
+            if method_data is not None:
                 for key, value in method_data.items():
                     _data = methods.add_element("data", value)
                     _data.add_element("name", key)
@@ -4366,7 +4366,7 @@ class Gmp(GvmProtocol):
 
             events = cmd.add_element("event", event.value)
 
-            if not event_data is None:
+            if event_data is not None:
                 for key, value in event_data.items():
                     _data = events.add_element("data", value)
                     _data.add_element("name", key)
@@ -4934,7 +4934,7 @@ class Gmp(GvmProtocol):
         cmd.set_attribute("note_id", note_id)
         cmd.add_element("text", text)
 
-        if not seconds_active is None:
+        if seconds_active is not None:
             cmd.add_element("active", str(seconds_active))
 
         if hosts:
@@ -5014,7 +5014,7 @@ class Gmp(GvmProtocol):
         cmd.set_attribute("override_id", override_id)
         cmd.add_element("text", text)
 
-        if not seconds_active is None:
+        if seconds_active is not None:
             cmd.add_element("active", str(seconds_active))
 
         if hosts:
@@ -5722,12 +5722,12 @@ class Gmp(GvmProtocol):
         if snmp_credential_id:
             cmd.add_element("snmp_credential", attrs={"id": snmp_credential_id})
 
-        if not reverse_lookup_only is None:
+        if reverse_lookup_only is not None:
             cmd.add_element(
                 "reverse_lookup_only", _to_bool(reverse_lookup_only)
             )
 
-        if not reverse_lookup_unify is None:
+        if reverse_lookup_unify is not None:
             cmd.add_element(
                 "reverse_lookup_unify", _to_bool(reverse_lookup_unify)
             )
@@ -5795,7 +5795,7 @@ class Gmp(GvmProtocol):
         if target_id:
             cmd.add_element("target", attrs={"id": target_id})
 
-        if not alterable is None:
+        if alterable is not None:
             cmd.add_element("alterable", _to_bool(alterable))
 
         if hosts_ordering:
@@ -5948,7 +5948,7 @@ class Gmp(GvmProtocol):
         cmd = XmlCommand("move_task")
         cmd.set_attribute("task_id", task_id)
 
-        if not slave_id is None:
+        if slave_id is not None:
             cmd.set_attribute("slave_id", slave_id)
 
         return self._send_xml_command(cmd)

--- a/gvm/protocols/gmpv8/__init__.py
+++ b/gvm/protocols/gmpv8/__init__.py
@@ -756,7 +756,7 @@ class Gmp(Gmpv7):
 
         _add_filter(cmd, filter, filter_id)
 
-        if not trash is None:
+        if trash is not None:
             cmd.set_attribute("trash", _to_bool(trash))
 
         return self._send_xml_command(cmd)

--- a/gvm/protocols/gmpv9/__init__.py
+++ b/gvm/protocols/gmpv9/__init__.py
@@ -404,7 +404,7 @@ class Gmp(Gmpv8):
         if comment:
             cmd.add_element("comment", comment)
 
-        if not alterable is None:
+        if alterable is not None:
             cmd.add_element("alterable", _to_bool(alterable))
 
         if hosts_ordering:


### PR DESCRIPTION
Address anti-pattern in conditionals: Use `if foo is not None` instead
of `if not foo is None` and `if foo not in (set)` instead of `if not foo
in (set)`.

See
https://www.python.org/dev/peps/pep-0008/#programming-recommendations
for recommendation.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
