### PR TITLE
Drop unused import 'enum'

### DIFF
--- a/gvm/protocols/gmpv7/__init__.py
+++ b/gvm/protocols/gmpv7/__init__.py
@@ -28,7 +28,6 @@ import collections
 import logging
 import numbers
 
-from enum import Enum
 from typing import Any, List, Optional, Callable
 
 from lxml import etree

--- a/gvm/protocols/gmpv8/__init__.py
+++ b/gvm/protocols/gmpv8/__init__.py
@@ -26,7 +26,6 @@ Module for communication with gvmd in `Greenbone Management Protocol version 8`_
 """
 import warnings
 
-from enum import Enum
 from typing import Any, List, Optional
 
 from gvm.errors import InvalidArgument, InvalidArgumentType, RequiredArgument

--- a/gvm/protocols/gmpv9/__init__.py
+++ b/gvm/protocols/gmpv9/__init__.py
@@ -27,7 +27,6 @@ Module for communication with gvmd in `Greenbone Management Protocol version 9`_
 import collections
 import numbers
 
-from enum import Enum
 from typing import Any, List, Optional
 
 from gvm.errors import InvalidArgument, InvalidArgumentType, RequiredArgument


### PR DESCRIPTION
The `__init__.py`s of `gmpv{7,8,9}` were importing the package `enum`
without actually using it.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
