### PR TITLE
Raise a GvmError if it isn't possible to connect

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+### Changed
+
+* If it isn't possible to connect to a Unix Domain Socket a GvmError is raised
+  now [#207](https://github.com/greenbone/python-gvm/pull/207)
+
+### Fixed
+
+### Removed
+
+[Unreleased]: https://github.com/greenbone/python-gvm/compare/v1.4.0...master
+
 ## [1.4.0]
 
 ### Added

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -353,6 +353,10 @@ class UnixSocketConnection(GvmConnection):
             raise GvmError(
                 "Socket {path} does not exist".format(path=self.path)
             ) from None
+        except ConnectionError:
+            raise GvmError(
+                "Could not connect to socket {}".format(self.path)
+            ) from None
 
 
 class DebugConnection:


### PR DESCRIPTION
If it isn't possible to connect to a unix socket a GvmError is raised
now.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [n/a] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [n/a] Documentation
