### PR TITLE
Don't crash when modifying an alert with an event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 * Refactored Gmp classes into mixins [#254](https://github.com/greenbone/python-gvm/pull/254)
 
+### Fixed
+
+* Require method and condition arguments for modify_alert with an event [#267](https://github.com/greenbone/python-gvm/pull/267)
+
 [Unreleased]: https://github.com/greenbone/python-gvm/compare/v1.6.0...master
 
 ## [1.6.0] - 2020-06-10

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -103,6 +103,16 @@ def _check_event(
     event: AlertEvent, condition: AlertCondition, method: AlertMethod
 ):
     if event == AlertEvent.TASK_RUN_STATUS_CHANGED:
+        if not condition:
+            raise RequiredArgument(
+                "condition is required for event {}".format(event.name),
+            )
+
+        if not method:
+            raise RequiredArgument(
+                "method is required for event {}".format(event.name),
+            )
+
         if condition not in (
             AlertCondition.ALWAYS,
             AlertCondition.FILTER_COUNT_CHANGED,
@@ -133,6 +143,16 @@ def _check_event(
         AlertEvent.NEW_SECINFO_ARRIVED,
         AlertEvent.UPDATED_SECINFO_ARRIVED,
     ):
+        if not condition:
+            raise RequiredArgument(
+                "condition is required for event {}".format(event.name),
+            )
+
+        if not method:
+            raise RequiredArgument(
+                "method is required for event {}".format(event.name),
+            )
+
         if condition not in (AlertCondition.ALWAYS,):
             raise InvalidArgument(
                 "Invalid condition {} for event {}".format(

--- a/tests/protocols/gmpv7/testcmds/test_modify_alert.py
+++ b/tests/protocols/gmpv7/testcmds/test_modify_alert.py
@@ -90,6 +90,50 @@ class GmpModifyAlertTestCase:
                 method='ipsum',
             )
 
+    def test_modify_alert_with_event_missing_method(self):
+        with self.assertRaisesRegex(RequiredArgument, "method is required"):
+            self.gmp.modify_alert(
+                alert_id='a1',
+                event=AlertEvent.TASK_RUN_STATUS_CHANGED,
+                condition=AlertCondition.ALWAYS,
+            )
+
+        with self.assertRaisesRegex(RequiredArgument, "method is required"):
+            self.gmp.modify_alert(
+                alert_id='a1',
+                event=AlertEvent.NEW_SECINFO_ARRIVED,
+                condition=AlertCondition.ALWAYS,
+            )
+
+        with self.assertRaisesRegex(RequiredArgument, "method is required"):
+            self.gmp.modify_alert(
+                alert_id='a1',
+                event=AlertEvent.UPDATED_SECINFO_ARRIVED,
+                condition=AlertCondition.ALWAYS,
+            )
+
+    def test_modify_alert_with_event_missing_condition(self):
+        with self.assertRaisesRegex(RequiredArgument, "condition is required"):
+            self.gmp.modify_alert(
+                alert_id='a1',
+                event=AlertEvent.TASK_RUN_STATUS_CHANGED,
+                method=AlertMethod.SCP,
+            )
+
+        with self.assertRaisesRegex(RequiredArgument, "condition is required"):
+            self.gmp.modify_alert(
+                alert_id='a1',
+                event=AlertEvent.NEW_SECINFO_ARRIVED,
+                method=AlertMethod.SCP,
+            )
+
+        with self.assertRaisesRegex(RequiredArgument, "condition is required"):
+            self.gmp.modify_alert(
+                alert_id='a1',
+                event=AlertEvent.UPDATED_SECINFO_ARRIVED,
+                method=AlertMethod.SCP,
+            )
+
     def test_modify_alert_invalid_condition_for_secinfo(self):
         with self.assertRaises(InvalidArgumentType):
             self.gmp.modify_alert(


### PR DESCRIPTION
If an alert is modified containing only and event without either a
condition or method python gvm crashed by raising a `AttributeError:
'NoneType' object has no attribute 'name'`. With this change it has been
made obvious that a condition and method is required too.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
