### PR TITLE
Update pylint to 2.6.0

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -78,7 +78,7 @@ class XmlReader:
                 "Cannot parse XML response. Response data "
                 "read {0}".format(data),
                 e,
-            )
+            ) from None
 
 
 class GvmConnection(XmlReader):
@@ -235,7 +235,7 @@ class SSHConnection(GvmConnection):
             paramiko.AuthenticationException,
             paramiko.SSHException,
         ) as e:
-            raise GvmError("SSH Connection failed", e)
+            raise GvmError("SSH Connection failed", e) from None
 
     def _read(self):
         return self._stdout.channel.recv(BUF_SIZE)

--- a/gvm/protocols/gmpv208/types.py
+++ b/gvm/protocols/gmpv208/types.py
@@ -170,7 +170,7 @@ def get_entity_type_from_string(
         raise InvalidArgument(
             argument='entity_type',
             function=get_entity_type_from_string.__name__,
-        )
+        ) from None
 
 
 class FilterType(Enum):
@@ -235,7 +235,7 @@ def get_filter_type_from_string(
         raise InvalidArgument(
             argument='filter_type',
             function=get_filter_type_from_string.__name__,
-        )
+        ) from None
 
 
 class InfoType(Enum):
@@ -262,4 +262,4 @@ def get_info_type_from_string(info_type: Optional[str]) -> Optional[InfoType]:
     except KeyError:
         raise InvalidArgument(
             argument='info_type', function=get_info_type_from_string.__name__
-        )
+        ) from None

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -524,10 +524,10 @@ class GmpV7Mixin(GvmProtocol):
 
         try:
             cmd.append_xml_str(config)
-        except etree.XMLSyntaxError:
+        except etree.XMLSyntaxError as e:
             raise InvalidArgument(
                 function=self.import_config.__name__, argument='config'
-            )
+            ) from e
 
         return self._send_xml_command(cmd)
 
@@ -1346,7 +1346,7 @@ class GmpV7Mixin(GvmProtocol):
         except etree.XMLSyntaxError as e:
             raise InvalidArgument(
                 "Invalid xml passed as report to import_report {}".format(e)
-            )
+            ) from None
 
         return self._send_xml_command(cmd)
 

--- a/gvm/protocols/gmpv7/types.py
+++ b/gvm/protocols/gmpv7/types.py
@@ -173,7 +173,7 @@ def get_alert_method_from_string(
         raise InvalidArgument(
             argument='alert_method',
             function=get_alert_method_from_string.__name__,
-        )
+        ) from None
 
 
 class AliveTest(Enum):
@@ -258,7 +258,7 @@ def get_asset_type_from_string(
     except KeyError:
         raise InvalidArgument(
             argument='asset_type', function=get_asset_type_from_string.__name__
-        )
+        ) from None
 
 
 class CredentialFormat(Enum):
@@ -283,7 +283,7 @@ def get_credential_format_from_string(
         raise InvalidArgument(
             argument='credential_format',
             function=get_credential_format_from_string.__name__,
-        )
+        ) from None
 
 
 class CredentialType(Enum):
@@ -309,7 +309,7 @@ def get_credential_type_from_string(
         raise InvalidArgument(
             argument='credential_type',
             function=get_credential_type_from_string.__name__,
-        )
+        ) from None
 
 
 class EntityType(Enum):
@@ -369,7 +369,7 @@ def get_entity_type_from_string(
         raise InvalidArgument(
             argument='entity_type',
             function=get_entity_type_from_string.__name__,
-        )
+        ) from None
 
 
 class FeedType(Enum):
@@ -391,7 +391,7 @@ def get_feed_type_from_string(feed_type: Optional[str]) -> Optional[FeedType]:
     except KeyError:
         raise InvalidArgument(
             argument='feed_type', function=get_feed_type_from_string.__name__
-        )
+        ) from None
 
 
 class FilterType(Enum):
@@ -448,7 +448,7 @@ def get_filter_type_from_string(
         raise InvalidArgument(
             argument='filter_type',
             function=get_filter_type_from_string.__name__,
-        )
+        ) from None
 
 
 class HostsOrdering(Enum):
@@ -475,7 +475,7 @@ def get_hosts_ordering_from_string(
         raise InvalidArgument(
             argument='hosts_ordering',
             function=get_hosts_ordering_from_string.__name__,
-        )
+        ) from None
 
 
 class InfoType(Enum):
@@ -503,7 +503,7 @@ def get_info_type_from_string(info_type: Optional[str]) -> Optional[InfoType]:
     except KeyError:
         raise InvalidArgument(
             argument='info_type', function=get_info_type_from_string.__name__
-        )
+        ) from None
 
 
 class PermissionSubjectType(Enum):
@@ -533,7 +533,7 @@ def get_permission_subject_type_from_string(
         raise InvalidArgument(
             argument='subject_type',
             function=get_permission_subject_type_from_string.__name__,
-        )
+        ) from None
 
 
 class PortRangeType(Enum):
@@ -560,7 +560,7 @@ def get_port_range_type_from_string(
         raise InvalidArgument(
             argument='port_range_type',
             function=get_port_range_type_from_string.__name__,
-        )
+        ) from None
 
 
 class ScannerType(Enum):
@@ -635,7 +635,7 @@ def get_snmp_auth_algorithm_from_string(
         raise InvalidArgument(
             argument='algorithm',
             function=get_snmp_auth_algorithm_from_string.__name__,
-        )
+        ) from None
 
 
 class SnmpPrivacyAlgorithm(Enum):
@@ -660,7 +660,7 @@ def get_snmp_privacy_algorithm_from_string(
         raise InvalidArgument(
             argument='algorithm',
             function=get_snmp_privacy_algorithm_from_string.__name__,
-        )
+        ) from None
 
 
 class SeverityLevel(Enum):
@@ -687,7 +687,7 @@ def get_severity_level_from_string(
         raise InvalidArgument(
             argument='severity_level',
             function=get_severity_level_from_string.__name__,
-        )
+        ) from None
 
 
 class TimeUnit(Enum):
@@ -714,4 +714,4 @@ def get_time_unit_from_string(time_unit: Optional[str]) -> Optional[TimeUnit]:
         raise InvalidArgument(
             argument='severity_level',
             function=get_severity_level_from_string.__name__,
-        )
+        ) from None

--- a/gvm/protocols/gmpv8/types.py
+++ b/gvm/protocols/gmpv8/types.py
@@ -165,7 +165,7 @@ def get_entity_type_from_string(
         raise InvalidArgument(
             argument='entity_type',
             function=get_entity_type_from_string.__name__,
-        )
+        ) from None
 
 
 class FilterType(Enum):
@@ -227,7 +227,7 @@ def get_filter_type_from_string(
         raise InvalidArgument(
             argument='filter_type',
             function=get_filter_type_from_string.__name__,
-        )
+        ) from None
 
 
 class CredentialType(Enum):
@@ -256,7 +256,7 @@ def get_credential_type_from_string(
         raise InvalidArgument(
             argument='credential_type',
             function=get_credential_type_from_string.__name__,
-        )
+        ) from None
 
 
 class TicketStatus(Enum):
@@ -281,4 +281,4 @@ def get_ticket_status_from_string(
         raise InvalidArgument(
             argument='ticket_status',
             function=get_ticket_status_from_string.__name__,
-        )
+        ) from None

--- a/gvm/protocols/gmpv9/types.py
+++ b/gvm/protocols/gmpv9/types.py
@@ -164,7 +164,7 @@ def get_entity_type_from_string(
         raise InvalidArgument(
             argument='entity_type',
             function=get_entity_type_from_string.__name__,
-        )
+        ) from None
 
 
 class AlertEvent(Enum):
@@ -304,7 +304,7 @@ def get_alert_method_from_string(
         raise InvalidArgument(
             argument='alert_method',
             function=get_alert_method_from_string.__name__,
-        )
+        ) from None
 
 
 class FilterType(Enum):
@@ -370,7 +370,7 @@ def get_filter_type_from_string(
         raise InvalidArgument(
             argument='filter_type',
             function=get_filter_type_from_string.__name__,
-        )
+        ) from None
 
 
 class ScannerType(Enum):
@@ -456,4 +456,4 @@ def __get_usage_type_from_string(
         raise InvalidArgument(
             argument='usage_type',
             function=__get_usage_type_from_string.__name__,
-        )
+        ) from None

--- a/poetry.lock
+++ b/poetry.lock
@@ -35,6 +35,7 @@ version = ">=1.4.0,<1.5"
 [[package]]
 category = "dev"
 description = "Classes Without Boilerplate"
+marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "attrs"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
@@ -169,7 +170,7 @@ version = "7.1.2"
 [[package]]
 category = "dev"
 description = "Cross-platform colored terminal text."
-marker = "platform_system == \"Windows\" or sys_platform == \"win32\" or python_version >= \"3.6\" and python_version < \"4.0\" and platform_system == \"Windows\""
+marker = "sys_platform == \"win32\" or platform_system == \"Windows\" or python_version >= \"3.6\" and python_version < \"4.0\" and platform_system == \"Windows\""
 name = "colorama"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
@@ -391,12 +392,12 @@ description = "python code static checker"
 name = "pylint"
 optional = false
 python-versions = ">=3.5.*"
-version = "2.5.3"
+version = "2.6.0"
 
 [package.dependencies]
 astroid = ">=2.4.0,<=2.5"
 colorama = "*"
-isort = ">=4.2.5,<5"
+isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
 toml = ">=0.7.1"
 
@@ -641,6 +642,7 @@ version = "1.12.1"
 
 [metadata]
 content-hash = "c9dff4d66f1e1dc103afbd4299b0ff07e2bbfe11db7517d761b580a0e6c8c0dc"
+lock-version = "1.0"
 python-versions = "^3.5.2"
 
 [metadata.files]
@@ -952,8 +954,8 @@ pygments = [
     {file = "Pygments-2.6.1.tar.gz", hash = "sha256:647344a061c249a3b74e230c739f434d7ea4d8b1d5f3721bc0f3558049b38f44"},
 ]
 pylint = [
-    {file = "pylint-2.5.3-py3-none-any.whl", hash = "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"},
-    {file = "pylint-2.5.3.tar.gz", hash = "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc"},
+    {file = "pylint-2.6.0-py3-none-any.whl", hash = "sha256:bfe68f020f8a0fece830a22dd4d5dddb4ecc6137db04face4c3420a46a52239f"},
+    {file = "pylint-2.6.0.tar.gz", hash = "sha256:bb4a908c9dadbc3aac18860550e870f58e1a02c9f2c204fdf5693d73be061210"},
 ]
 pynacl = [
     {file = "PyNaCl-1.4.0-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:ea6841bc3a76fa4942ce00f3bda7d436fda21e2d91602b9e21b7ca9ecab8f3ff"},


### PR DESCRIPTION
**What**:

Handle newly introduced raise-missing-from feature by either raise from
the catched exception explicitly or by surpressing the original
traceback.

```
except Error as e:
    raise MyException()
```

is actually a

```
except Error as e:
    raise MyException() from e
```

See https://docs.python.org/3/reference/simple_stmts.html#the-raise-statement
for all details.

Most of the time we don't want to show the original traceback therefore a `from None` is used.

**Why**:

A new version of pylint has been released.

**How**:

`poetry run pylint --disable=R gvm tests`

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests (N/A)
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry (N/A)
- [ ] Documentation (N/A)
