### PR TITLE
Rename AliveTest ARP_PING from APR_PING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 ### Removed
+
 ### Fixed
+
+* `ARP_PING` is now a field of `AliveTypes`, the old `APR_PING` name is still available. [#281](https://github.com/greenbone/python-gvm/pull/281)
 
 [Unreleased]: https://github.com/greenbone/python-gvm/compare/v20.8.0...HEAD
 

--- a/gvm/protocols/gmpv7/types.py
+++ b/gvm/protocols/gmpv7/types.py
@@ -183,7 +183,8 @@ class AliveTest(Enum):
     ICMP_PING = 'ICMP Ping'
     TCP_ACK_SERVICE_PING = 'TCP-ACK Service Ping'
     TCP_SYN_SERVICE_PING = 'TCP-SYN Service Ping'
-    APR_PING = 'ARP Ping'
+    ARP_PING = 'ARP Ping'
+    APR_PING = 'ARP Ping'  # Alias for ARP_PING
     ICMP_AND_TCP_ACK_SERVICE_PING = 'ICMP & TCP-ACK Service Ping'
     ICMP_AND_ARP_PING = 'ICMP & ARP Ping'
     TCP_ACK_SERVICE_AND_ARP_PING = 'TCP-ACK Service & ARP Ping'
@@ -215,7 +216,7 @@ def get_alive_test_from_string(
         return AliveTest.TCP_SYN_SERVICE_PING
 
     if alive_test == 'arp ping':
-        return AliveTest.APR_PING
+        return AliveTest.ARP_PING
 
     if alive_test == 'icmp & tcp-ack service ping':
         return AliveTest.ICMP_AND_TCP_ACK_SERVICE_PING

--- a/tests/protocols/gmpv7/testtypes/test_alive_test.py
+++ b/tests/protocols/gmpv7/testtypes/test_alive_test.py
@@ -51,7 +51,7 @@ class GetAliveTestFromStringTestCase(unittest.TestCase):
 
     def test_arp_ping(self):
         ct = get_alive_test_from_string('ARP Ping')
-        self.assertEqual(ct, AliveTest.APR_PING)
+        self.assertEqual(ct, AliveTest.ARP_PING)
 
     def test_icmp_and_tcp_ack_service_ping(self):
         ct = get_alive_test_from_string('ICMP & TCP-ACK Service Ping')

--- a/tests/protocols/gmpv8/testtypes/test_alive_test.py
+++ b/tests/protocols/gmpv8/testtypes/test_alive_test.py
@@ -51,7 +51,7 @@ class GetAliveTestFromStringTestCase(unittest.TestCase):
 
     def test_arp_ping(self):
         ct = get_alive_test_from_string('ARP Ping')
-        self.assertEqual(ct, AliveTest.APR_PING)
+        self.assertEqual(ct, AliveTest.ARP_PING)
 
     def test_icmp_and_tcp_ack_service_ping(self):
         ct = get_alive_test_from_string('ICMP & TCP-ACK Service Ping')


### PR DESCRIPTION
... add an alias from the old name

**What**:

Make the enum name for Arp Ping AliveTest.ARP_PING rather than APR_PING.

**Why**:

To make finding the name as convenient as possible.

**How**:

See tests.

**Checklist**:

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation n/a
