### PR TITLE
modify_task adds <alert id="0"/> if alert_ids array is empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * `ARP_PING` is now a field of `AliveTypes`, the old `APR_PING` name is still available. [#281](https://github.com/greenbone/python-gvm/pull/281)
+* `modify_task` adds `<alert id="0"/>` if alert_ids array is empty. [#285](https://github.com/greenbone/python-gvm/pull/285)
 
 [20.8.1]: https://github.com/greenbone/python-gvm/compare/v20.8.0...HEAD
 

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -5913,8 +5913,11 @@ class GmpV7Mixin(GvmProtocol):
                     arg_type='list',
                 )
 
-            for alert in alert_ids:
-                cmd.add_element("alert", attrs={"id": str(alert)})
+            if len(alert_ids) == 0:
+                cmd.add_element("alert", attrs={"id": "0"})
+            else:
+                for alert in alert_ids:
+                    cmd.add_element("alert", attrs={"id": str(alert)})
 
         if observers is not None:
             if not _is_list_like(observers):

--- a/tests/protocols/gmpv7/testcmds/test_modify_task.py
+++ b/tests/protocols/gmpv7/testcmds/test_modify_task.py
@@ -103,6 +103,13 @@ class GmpModifyTaskCommandTestCase:
         with self.assertRaises(InvalidArgumentType):
             self.gmp.modify_task(task_id='t1', alert_ids='a1')
 
+    def test_modify_task_with_empty_alert_ids(self):
+        self.gmp.modify_task(task_id='t1', alert_ids=[])
+
+        self.connection.send.has_been_called_with(
+            '<modify_task task_id="t1">' '<alert id="0"/>' '</modify_task>'
+        )
+
     def test_modify_task_with_alterable(self):
         self.gmp.modify_task(task_id='t1', alterable=True)
 


### PR DESCRIPTION
**What**:
If `modify_task` gets the argument `alert_ids=[]`, it sends `<alert id="0" />` along with the `<modify_task />` command.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

Because currently, it is not possible to remove all alerts by sending an empty alert array. Currently, an empty array doesn't add any alert elements which says to the backend not to touch the task alerts.
 
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
