### PR TITLE
Force garbage clean up when disconnect.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+- Force garbage clean up when disconnect. [#286](https://github.com/greenbone/python-gvm/pull/286)
 
 [Unreleased]: https://github.com/greenbone/python-gvm/compare/v20.8.1...HEAD
 

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -244,6 +244,17 @@ class SSHConnection(GvmConnection):
         # shutdown socket for sending. only allow reading data afterwards
         self._stdout.channel.shutdown(socketlib.SHUT_WR)
 
+    def disconnect(self):
+        """Disconnect and close the connection to the remote server"""
+        try:
+            if self._socket is not None:
+                self._socket.close()
+        except OSError as e:
+            logger.debug("Connection closing error: %s", e)
+
+        if self._socket:
+            del self._socket, self._stdin, self._stdout, self._stderr
+
 
 class TLSConnection(GvmConnection):
     """


### PR DESCRIPTION
**What**:


The disconnect method is overwritten because this is only for ssh connection, since
the problem is present in paramiko. This is only a workaround from the python-gvm side.

**Why**:
For some reason, sometimes the garbage is not cleaned up automatically when sys.exit
- https://github.com/paramiko/paramiko/issues/1078
- https://stackoverflow.com/questions/37556888/why-does-paramiko-sporadically-raise-an-exception

**How**:

```
from gvm.protocols.gmp import Gmp

# IP address or DNS name of the remote host
hostname = '192.168.x.x'
connection = SSHConnection(hostname=hostname)

# credentials of a web user
username = 'user'
password = 'pass'

with Gmp(connection=connection) as gmp:
     gmp.authenticate(username, password)
     response = gmp.get_version()
     print(response, flush=True)
     gmp.disconnect()
``` 
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation N/A
