### PR TITLE
Added tasks parameter to get_config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Added
 ### Changed
+* Added the `tasks` parameter to `get_config()`. [#289](https://github.com/greenbone/python-gvm/pull/289)
 ### Deprecated
 ### Removed
 ### Fixed

--- a/gvm/protocols/gmpv208/gmpv208.py
+++ b/gvm/protocols/gmpv208/gmpv208.py
@@ -177,56 +177,6 @@ class GmpV208Mixin(GvmProtocol):
         cmd.set_attribute("details", "1")
         return self._send_xml_command(cmd)
 
-    def modify_schedule(
-        self,
-        schedule_id: str,
-        *,
-        name: Optional[str] = None,
-        icalendar: Optional[str] = None,
-        timezone: Optional[str] = None,
-        comment: Optional[str] = None
-    ) -> Any:
-        """Modifies an existing schedule
-
-        Arguments:
-            schedule_id: UUID of the schedule to be modified
-            name: Name of the schedule
-            icalendar: `iCalendar`_ (RFC 5545) based data.
-            timezone: Timezone to use for the icalender events e.g
-                Europe/Berlin. If the datetime values in the icalendar data are
-                missing timezone information this timezone gets applied.
-                Otherwise the datetime values from the icalendar data are
-                displayed in this timezone
-            commenhedule.
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-
-        .. _iCalendar:
-            https://tools.ietf.org/html/rfc5545
-        """
-        if not schedule_id:
-            raise RequiredArgument(
-                function=self.modify_schedule.__name__, argument='schedule_id'
-            )
-
-        cmd = XmlCommand("modify_schedule")
-        cmd.set_attribute("schedule_id", schedule_id)
-
-        if name:
-            cmd.add_element("name", name)
-
-        if icalendar:
-            cmd.add_element("icalendar", icalendar)
-
-        if timezone:
-            cmd.add_element("timezone", timezone)
-
-        if comment:
-            cmd.add_element("comment", comment)
-
-        return self._send_xml_command(cmd)
-
     def create_target(
         self,
         name: str,
@@ -271,6 +221,10 @@ class GmpV208Mixin(GvmProtocol):
         Returns:
             The response. See :py:meth:`send_command` for details.
         """
+
+        cmd = XmlCommand("create_target")
+        _xmlname = cmd.add_element("name", name)
+
         if make_unique is not None:
             warnings.warn(
                 'create_target make_unique argument is deprecated '
@@ -282,16 +236,6 @@ class GmpV208Mixin(GvmProtocol):
             raise RequiredArgument(
                 function=self.create_target.__name__, argument='name'
             )
-
-        # since 20.08 one of port_range or port_list_id is required!
-        if not port_range and not port_list_id:
-            raise RequiredArgument(
-                function=self.create_target.__name__,
-                argument='port_range or port_list_id',
-            )
-
-        cmd = XmlCommand("create_target")
-        _xmlname = cmd.add_element("name", name)
 
         if asset_hosts_filter:
             cmd.add_element(
@@ -345,6 +289,13 @@ class GmpV208Mixin(GvmProtocol):
         if reverse_lookup_unify is not None:
             cmd.add_element(
                 "reverse_lookup_unify", _to_bool(reverse_lookup_unify)
+            )
+
+        # since 20.08 one of port_range or port_list_id is required!
+        if not port_range and not port_list_id:
+            raise RequiredArgument(
+                function=self.create_target.__name__,
+                argument='port_range or port_list_id',
             )
 
         if port_range:

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -3000,6 +3000,7 @@ class GmpV7Mixin(GvmProtocol):
 
         Arguments:
             config_id: UUID of an existing scan config
+            tasks: Whether to get tasks using this config
 
         Returns:
             The response. See :py:meth:`send_command` for details.

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -2993,7 +2993,9 @@ class GmpV7Mixin(GvmProtocol):
 
         return self._send_xml_command(cmd)
 
-    def get_config(self, config_id: str) -> Any:
+    def get_config(
+        self, config_id: str, *, tasks: Optional[bool] = None
+    ) -> Any:
         """Request a single scan config
 
         Arguments:
@@ -3010,6 +3012,9 @@ class GmpV7Mixin(GvmProtocol):
             )
 
         cmd.set_attribute("config_id", config_id)
+
+        if tasks is not None:
+            cmd.set_attribute("tasks", _to_bool(tasks))
 
         # for single entity always request all details
         cmd.set_attribute("details", "1")

--- a/gvm/protocols/gmpv9/gmpv9.py
+++ b/gvm/protocols/gmpv9/gmpv9.py
@@ -743,7 +743,9 @@ class GmpV9Mixin(GvmProtocol):
             trash=trash,
         )
 
-    def get_config(self, config_id: str) -> Any:
+    def get_config(
+        self, config_id: str, *, tasks: Optional[bool] = None
+    ) -> Any:
         """Request a single scan config
 
         Arguments:
@@ -752,7 +754,9 @@ class GmpV9Mixin(GvmProtocol):
         Returns:
             The response. See :py:meth:`send_command` for details.
         """
-        return self.__get_config(config_id, UsageType.SCAN)
+        return self.__get_config(
+            config_id=config_id, usage_type=UsageType.SCAN, tasks=tasks
+        )
 
     def get_policy(self, policy_id: str) -> Any:
         """Request a single policy
@@ -1086,7 +1090,13 @@ class GmpV9Mixin(GvmProtocol):
 
         return self._send_xml_command(cmd)
 
-    def __get_config(self, config_id: str, usage_type: UsageType) -> Any:
+    def __get_config(
+        self,
+        config_id: str,
+        usage_type: UsageType,
+        *,
+        tasks: Optional[bool] = None
+    ) -> Any:
         if not config_id:
             raise RequiredArgument(
                 function=self.get_config.__name__, argument='config_id'
@@ -1094,7 +1104,11 @@ class GmpV9Mixin(GvmProtocol):
 
         cmd = XmlCommand("get_configs")
         cmd.set_attribute("config_id", config_id)
+
         cmd.set_attribute("usage_type", usage_type.value)
+
+        if tasks is not None:
+            cmd.set_attribute("tasks", _to_bool(tasks))
 
         # for single entity always request all details
         cmd.set_attribute("details", "1")

--- a/gvm/protocols/gmpv9/gmpv9.py
+++ b/gvm/protocols/gmpv9/gmpv9.py
@@ -750,6 +750,7 @@ class GmpV9Mixin(GvmProtocol):
 
         Arguments:
             config_id: UUID of an existing scan config
+            tasks: Whether to get tasks using this config
 
         Returns:
             The response. See :py:meth:`send_command` for details.

--- a/tests/protocols/gmpv7/testcmds/test_get_config.py
+++ b/tests/protocols/gmpv7/testcmds/test_get_config.py
@@ -29,6 +29,13 @@ class GmpGetConfigTestCase:
             '<get_configs config_id="a1" details="1"/>'
         )
 
+    def test_get_config_with_tasks(self):
+        self.gmp.get_config('a1', tasks=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs config_id="a1" tasks="1" details="1"/>'
+        )
+
     def test_fail_without_config_id(self):
         with self.assertRaises(GvmError):
             self.gmp.get_config(None)

--- a/tests/protocols/gmpv9/testcmds/test_get_config.py
+++ b/tests/protocols/gmpv9/testcmds/test_get_config.py
@@ -29,6 +29,14 @@ class GmpGetConfigTestCase:
             '<get_configs config_id="a1" usage_type="scan" details="1"/>'
         )
 
+    def test_get_config_with_tasks(self):
+        self.gmp.get_config('a1', tasks=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs config_id="a1" usage_type="scan" '
+            'tasks="1" details="1"/>'
+        )
+
     def test_fail_without_config_id(self):
         with self.assertRaises(GvmError):
             self.gmp.get_config(None)


### PR DESCRIPTION
**What**:

If `get_config()` is called, `tasks` are not included.
So I added a optional parameter, to include tasks to the response

also removed unnecessary function from gmpv208

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

If a single config is requested, it should be possible to include tasks here ...
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
