### PR TITLE
Fix ScannerType check for newer protocols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Deprecated
 ### Removed
 ### Fixed
+* Fix ScannerType check for newer protocols. [#300](https://github.com/greenbone/python-gvm/pull/300)
 
 [Unreleased]: https://github.com/greenbone/python-gvm/compare/v20.9.0...HEAD
 

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -1458,11 +1458,11 @@ class GmpV7Mixin(GvmProtocol):
                 function=self.create_scanner.__name__, argument='credential_id'
             )
 
-        if not isinstance(scanner_type, ScannerType):
+        if not isinstance(scanner_type, self.types.ScannerType):
             raise InvalidArgumentType(
                 function=self.create_scanner.__name__,
                 argument='scanner_type',
-                arg_type=ScannerType.__name__,
+                arg_type=self.types.ScannerType.__name__,
             )
 
         cmd = XmlCommand("create_scanner")
@@ -5417,11 +5417,11 @@ class GmpV7Mixin(GvmProtocol):
         cmd.set_attribute("scanner_id", scanner_id)
 
         if scanner_type is not None:
-            if not isinstance(scanner_type, ScannerType):
+            if not isinstance(scanner_type, self.types.ScannerType):
                 raise InvalidArgumentType(
                     function=self.modify_scanner.__name__,
                     argument='scanner_type',
-                    arg_type=ScannerType.__name__,
+                    arg_type=self.types.ScannerType.__name__,
                 )
 
             cmd.add_element("type", scanner_type.value)

--- a/tests/protocols/gmpv208/test_v7_from_gmpv208.py
+++ b/tests/protocols/gmpv208/test_v7_from_gmpv208.py
@@ -136,10 +136,6 @@ class Gmpv208CreateRoleTestCase(GmpCreateRoleTestCase, Gmpv208TestCase):
     pass
 
 
-class Gmpv208CreateScannerTestCase(GmpCreateScannerTestCase, Gmpv208TestCase):
-    pass
-
-
 class Gmpv208CreateUserTestCase(GmpCreateUserTestCase, Gmpv208TestCase):
     pass
 
@@ -513,10 +509,6 @@ class Gmpv208ModifyReportFormatTestCase(
 
 
 class Gmpv208ModifyRoleTestCase(GmpModifyRoleTestCase, Gmpv208TestCase):
-    pass
-
-
-class Gmpv208ModifyScannerTestCase(GmpModifyScannerTestCase, Gmpv208TestCase):
     pass
 
 

--- a/tests/protocols/gmpv208/test_v9_from_gmpv208.py
+++ b/tests/protocols/gmpv208/test_v9_from_gmpv208.py
@@ -166,3 +166,14 @@ class Gmpv208ModifyTLSCertificateTestCase(
     GmpModifyTLSCertificateTestCase, Gmpv208TestCase
 ):
     pass
+
+
+class Gmpv208CreateScannerTestCase(
+    GmpCreateScannerTestCase, Gmpv208TestCase
+):
+    pass
+
+class Gmpv208ModifyScannerTestCase(
+    GmpModifyScannerTestCase, Gmpv208TestCase
+):
+    pass

--- a/tests/protocols/gmpv9/test_new_gmpv9.py
+++ b/tests/protocols/gmpv9/test_new_gmpv9.py
@@ -190,3 +190,15 @@ class Gmpv9ModifyTLSCertificateTestCase(
     GmpModifyTLSCertificateTestCase, Gmpv9TestCase
 ):
     pass
+
+
+class Gmpv9CreateScannerTestCase(
+    GmpCreateScannerTestCase, Gmpv9TestCase
+):
+    pass
+
+
+class Gmpv9ModifyScannerTestCase(
+    GmpModifyScannerTestCase, Gmpv9TestCase
+):
+    pass

--- a/tests/protocols/gmpv9/test_v7_from_gmpv9.py
+++ b/tests/protocols/gmpv9/test_v7_from_gmpv9.py
@@ -138,10 +138,6 @@ class Gmpv9CreateRoleTestCase(GmpCreateRoleTestCase, Gmpv9TestCase):
     pass
 
 
-class Gmpv9CreateScannerTestCase(GmpCreateScannerTestCase, Gmpv9TestCase):
-    pass
-
-
 class Gmpv9CreateUserTestCase(GmpCreateUserTestCase, Gmpv9TestCase):
     pass
 
@@ -529,10 +525,6 @@ class Gmpv9ModifyReportFormatTestCase(
 
 
 class Gmpv9ModifyRoleTestCase(GmpModifyRoleTestCase, Gmpv9TestCase):
-    pass
-
-
-class Gmpv9ModifyScannerTestCase(GmpModifyScannerTestCase, Gmpv9TestCase):
     pass
 
 

--- a/tests/protocols/gmpv9/testcmds/__init__.py
+++ b/tests/protocols/gmpv9/testcmds/__init__.py
@@ -58,3 +58,5 @@ from .test_modify_permission import GmpModifyPermissionTestCase
 from .test_modify_tag import GmpModifyTagTestCase
 from .test_modify_ticket import GmpModifyTicketTestCase
 from .test_modify_tls_certificate import GmpModifyTLSCertificateTestCase
+from .test_create_scanner import GmpCreateScannerTestCase
+from .test_modify_scanner import GmpModifyScannerTestCase

--- a/tests/protocols/gmpv9/testcmds/test_create_scanner.py
+++ b/tests/protocols/gmpv9/testcmds/test_create_scanner.py
@@ -1,0 +1,204 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import RequiredArgument, InvalidArgumentType
+
+from gvm.protocols.gmpv9 import ScannerType
+
+
+class GmpCreateScannerTestCase:
+    def test_create_scanner(self):
+        self.gmp.create_scanner(
+            name='foo',
+            host='localhost',
+            port=1234,
+            scanner_type=ScannerType.OSP_SCANNER_TYPE,
+            credential_id='c1',
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_scanner>'
+            '<name>foo</name>'
+            '<host>localhost</host>'
+            '<port>1234</port>'
+            '<type>1</type>'
+            '<credential id="c1"/>'
+            '</create_scanner>'
+        )
+
+    def test_create_scanner_missing_name(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name=None,
+                host='localhost',
+                port=1234,
+                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                credential_id='c1',
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name='',
+                host='localhost',
+                port=1234,
+                scanner_type='1',
+                credential_id='c1',
+            )
+
+    def test_create_scanner_missing_host(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name='foo',
+                host=None,
+                port=1234,
+                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                credential_id='c1',
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name='foo',
+                host='',
+                port=1234,
+                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                credential_id='c1',
+            )
+
+    def test_create_scanner_missing_port(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name='foo',
+                host='localhost',
+                port=None,
+                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                credential_id='c1',
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name='foo',
+                host='localhost',
+                port='',
+                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                credential_id='c1',
+            )
+
+    def test_create_scanner_missing_scanner_type(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name='foo',
+                host='localhost',
+                port=1234,
+                scanner_type=None,
+                credential_id='c1',
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name='foo',
+                host='localhost',
+                port=1234,
+                scanner_type='',
+                credential_id='c1',
+            )
+
+    def test_create_scanner_missing_credential_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name='foo',
+                host='localhost',
+                port=1234,
+                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                credential_id=None,
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scanner(
+                name='foo',
+                host='localhost',
+                port=1234,
+                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                credential_id='',
+            )
+
+    def test_create_scanner_invalid_scanner_type(self):
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.create_scanner(
+                name='foo',
+                host='localhost',
+                port=1234,
+                scanner_type='bar',
+                credential_id='c1',
+            )
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.create_scanner(
+                name='foo',
+                host='localhost',
+                port=1234,
+                scanner_type='55',
+                credential_id='c1',
+            )
+
+    def test_create_scanner_with_ca_pub(self):
+        self.gmp.create_scanner(
+            name='foo',
+            host='localhost',
+            port=1234,
+            ca_pub='foo',
+            scanner_type=ScannerType.OSP_SCANNER_TYPE,
+            credential_id='c1',
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_scanner>'
+            '<name>foo</name>'
+            '<host>localhost</host>'
+            '<port>1234</port>'
+            '<type>1</type>'
+            '<ca_pub>foo</ca_pub>'
+            '<credential id="c1"/>'
+            '</create_scanner>'
+        )
+
+    def test_create_scanner_with_comment(self):
+        self.gmp.create_scanner(
+            name='foo',
+            host='localhost',
+            port=1234,
+            scanner_type=ScannerType.OSP_SCANNER_TYPE,
+            credential_id='c1',
+            comment='bar',
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_scanner>'
+            '<name>foo</name>'
+            '<host>localhost</host>'
+            '<port>1234</port>'
+            '<type>1</type>'
+            '<credential id="c1"/>'
+            '<comment>bar</comment>'
+            '</create_scanner>'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmpv9/testcmds/test_modify_scanner.py
+++ b/tests/protocols/gmpv9/testcmds/test_modify_scanner.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import RequiredArgument, InvalidArgumentType
+from gvm.protocols.gmpv9 import ScannerType
+
+
+class GmpModifyScannerTestCase:
+    def test_modify_scanner(self):
+        self.gmp.modify_scanner(scanner_id='s1')
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1"/>'
+        )
+
+    def test_modify_scanner_missing_scanner_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scanner(scanner_id=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scanner(scanner_id='')
+
+    def test_modify_scanner_with_comment(self):
+        self.gmp.modify_scanner(scanner_id='s1', comment='foo')
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<comment>foo</comment>'
+            '</modify_scanner>'
+        )
+
+    def test_modify_scanner_with_host(self):
+        self.gmp.modify_scanner(scanner_id='s1', host='foo')
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<host>foo</host>'
+            '</modify_scanner>'
+        )
+
+    def test_modify_scanner_with_port(self):
+        self.gmp.modify_scanner(scanner_id='s1', port=1234)
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<port>1234</port>'
+            '</modify_scanner>'
+        )
+
+        self.gmp.modify_scanner(scanner_id='s1', port='1234')
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<port>1234</port>'
+            '</modify_scanner>'
+        )
+
+    def test_modify_scanner_with_name(self):
+        self.gmp.modify_scanner(scanner_id='s1', name='foo')
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<name>foo</name>'
+            '</modify_scanner>'
+        )
+
+    def test_modify_scanner_with_ca_pub(self):
+        self.gmp.modify_scanner(scanner_id='s1', ca_pub='foo')
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<ca_pub>foo</ca_pub>'
+            '</modify_scanner>'
+        )
+
+    def test_modify_scanner_with_credential_id(self):
+        self.gmp.modify_scanner(scanner_id='s1', credential_id='c1')
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<credential id="c1"/>'
+            '</modify_scanner>'
+        )
+
+    def test_modify_scanner_with_scanner_type(self):
+        self.gmp.modify_scanner(
+            scanner_id='s1', scanner_type=ScannerType.OSP_SCANNER_TYPE
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<type>1</type>'
+            '</modify_scanner>'
+        )
+
+        self.gmp.modify_scanner(
+            scanner_id='s1', scanner_type=ScannerType.OPENVAS_SCANNER_TYPE
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<type>2</type>'
+            '</modify_scanner>'
+        )
+
+        self.gmp.modify_scanner(
+            scanner_id='s1', scanner_type=ScannerType.CVE_SCANNER_TYPE
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<type>3</type>'
+            '</modify_scanner>'
+        )
+
+        self.gmp.modify_scanner(
+            scanner_id='s1', scanner_type=ScannerType.GMP_SCANNER_TYPE
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_scanner scanner_id="s1">'
+            '<type>4</type>'
+            '</modify_scanner>'
+        )
+
+    def test_modify_scanner_invalid_scanner_type(self):
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scanner(scanner_id='s1', scanner_type='')
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scanner(scanner_id='s1', scanner_type='-1')
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scanner(scanner_id='s1', scanner_type=1)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**What**:
Fix ScannerType check for newer protocols

**Why**:
In some cases using gmpv9 protocol or later, and passing the ScannerType to create_scanner, raise the error
`In create_scanner the argument scanner_type must be of type ScannerType`
**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation N/A
