### PR TITLE
Fixed TypeError when Port of gvm.connections.SSHConnection is None

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added `clone_report_format()` and `import_report_format()` [#309](https://github.com/greenbone/python-gvm/pull/309)
 * Added the `get_x_from_string()` functions to `latest` [#308](https://github.com/greenbone/python-gvm/pull/308)
-* Added tests for SSHConnection and GvmConnection [#321](https://github.com/greenbone/python-gvm/pull/321)
+* Added tests for constructor of SSHConnection, TLSConnection and GvmConnection [#321](https://github.com/greenbone/python-gvm/pull/321)
 
 ### Changed
 ### Deprecated
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Corrected `seconds_active` parameter to `days_active` for notes and overrides. [#307](https://github.com/greenbone/python-gvm/pull/307)
 * Fixed SSHConnection throws TypeError if port is None [#321](https://github.com/greenbone/python-gvm/pull/321)
 * Fixed GvmConnection timeout set to None if None is passed [#321](https://github.com/greenbone/python-gvm/pull/321)
+* Fixed TLSConnection values set to None instead of default values when None is passed for these values [#321](https://github.com/greenbone/python-gvm/pull/321)
 
 [Unreleased]: https://github.com/greenbone/python-gvm/compare/v20.9.1...HEAD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the `comment` parameter to `create_config`. [#294](https://github.com/greenbone/python-gvm/pull/294)
 ### Fixed
 * Fix ScannerType check for newer protocols. [#300](https://github.com/greenbone/python-gvm/pull/300)
+* Fix SSHConnection throws TypeError if port is None [#321](https://github.com/greenbone/python-gvm/pull/321)
 
 [20.9.1]: https://github.com/greenbone/python-gvm/compare/v20.9.0...HEAD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 * Corrected `seconds_active` parameter to `days_active` for notes and overrides. [#307](https://github.com/greenbone/python-gvm/pull/307)
+* Fixed SSHConnection throws TypeError if port is None [#321](https://github.com/greenbone/python-gvm/pull/321)
 
 [Unreleased]: https://github.com/greenbone/python-gvm/compare/v20.9.1...HEAD
 
@@ -29,7 +30,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the `comment` parameter to `create_config`. [#294](https://github.com/greenbone/python-gvm/pull/294)
 ### Fixed
 * Fix ScannerType check for newer protocols. [#300](https://github.com/greenbone/python-gvm/pull/300)
-* Fix SSHConnection throws TypeError if port is None [#321](https://github.com/greenbone/python-gvm/pull/321)
 
 [20.9.1]: https://github.com/greenbone/python-gvm/compare/v20.9.0...HEAD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added `clone_report_format()` and `import_report_format()` [#309](https://github.com/greenbone/python-gvm/pull/309)
 * Added the `get_x_from_string()` functions to `latest` [#308](https://github.com/greenbone/python-gvm/pull/308)
-* Added tests for constructor of SSHConnection, TLSConnection and GvmConnection [#321](https://github.com/greenbone/python-gvm/pull/321)
+* Added tests for constructor of SSHConnection, TLSConnection, UnixSocketConnection and GvmConnection [#321](https://github.com/greenbone/python-gvm/pull/321)
 
 ### Changed
 ### Deprecated
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Fixed SSHConnection throws TypeError if port is None [#321](https://github.com/greenbone/python-gvm/pull/321)
 * Fixed GvmConnection timeout set to None if None is passed [#321](https://github.com/greenbone/python-gvm/pull/321)
 * Fixed TLSConnection values set to None instead of default values when None is passed for these values [#321](https://github.com/greenbone/python-gvm/pull/321)
+* Fixed UnixSocketConnection values set to None instead of default when None is passed for these values [#321](https://github.com/greenbone/python-gvm/pull/321)
 
 [Unreleased]: https://github.com/greenbone/python-gvm/compare/v20.9.1...HEAD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 * Added `clone_report_format()` and `import_report_format()` [#309](https://github.com/greenbone/python-gvm/pull/309)
 * Added the `get_x_from_string()` functions to `latest` [#308](https://github.com/greenbone/python-gvm/pull/308)
+* Added tests for SSHConnection and GvmConnection [#321](https://github.com/greenbone/python-gvm/pull/321)
 
 ### Changed
 ### Deprecated
@@ -16,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 * Corrected `seconds_active` parameter to `days_active` for notes and overrides. [#307](https://github.com/greenbone/python-gvm/pull/307)
 * Fixed SSHConnection throws TypeError if port is None [#321](https://github.com/greenbone/python-gvm/pull/321)
+* Fixed GvmConnection timeout set to None if None is passed [#321](https://github.com/greenbone/python-gvm/pull/321)
 
 [Unreleased]: https://github.com/greenbone/python-gvm/compare/v20.9.1...HEAD
 

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -192,7 +192,7 @@ class SSHConnection(GvmConnection):
         super().__init__(timeout=timeout)
 
         self.hostname = hostname
-        self.port = int(port)
+        self.port = int(port) if port is not None else DEFAULT_SSH_PORT
         self.username = username
         self.password = password
 

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -40,6 +40,8 @@ DEFAULT_TIMEOUT = 60  # in seconds
 DEFAULT_GVM_PORT = 9390
 DEFAULT_UNIX_SOCKET_PATH = "/var/run/gvmd.sock"
 DEFAULT_SSH_PORT = 22
+DEFAULT_SSH_USERNAME = "gmp"
+DEFAULT_SSH_PASSWORD = ""
 DEFAULT_HOSTNAME = '127.0.0.1'
 MAX_SSH_DATA_LENGTH = 4095
 
@@ -186,15 +188,19 @@ class SSHConnection(GvmConnection):
         timeout: Optional[int] = DEFAULT_TIMEOUT,
         hostname: Optional[str] = DEFAULT_HOSTNAME,
         port: Optional[int] = DEFAULT_SSH_PORT,
-        username: Optional[str] = "gmp",
-        password: Optional[str] = ""
+        username: Optional[str] = DEFAULT_SSH_USERNAME,
+        password: Optional[str] = DEFAULT_SSH_PASSWORD
     ):
         super().__init__(timeout=timeout)
 
-        self.hostname = hostname
+        self.hostname = hostname if hostname is not None else DEFAULT_HOSTNAME
         self.port = int(port) if port is not None else DEFAULT_SSH_PORT
-        self.username = username
-        self.password = password
+        self.username = (
+            username if username is not None else DEFAULT_SSH_USERNAME
+        )
+        self.password = (
+            password if password is not None else DEFAULT_SSH_PASSWORD
+        )
 
     def _send_all(self, data):
         while data:

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -352,7 +352,7 @@ class UnixSocketConnection(GvmConnection):
     ):
         super().__init__(timeout=timeout)
 
-        self.path = path
+        self.path = path if path is not None else DEFAULT_UNIX_SOCKET_PATH
 
     def connect(self):
         """Connect to the UNIX socket"""

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -94,7 +94,7 @@ class GvmConnection(XmlReader):
 
     def __init__(self, timeout: Optional[int] = DEFAULT_TIMEOUT):
         self._socket = None
-        self._timeout = timeout
+        self._timeout = timeout if timeout is not None else DEFAULT_TIMEOUT
 
     def _read(self):
         return self._socket.recv(BUF_SIZE)

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -298,8 +298,8 @@ class TLSConnection(GvmConnection):
     ):
         super().__init__(timeout=timeout)
 
-        self.hostname = hostname
-        self.port = port
+        self.hostname = hostname if hostname is not None else DEFAULT_HOSTNAME
+        self.port = port if port is not None else DEFAULT_GVM_PORT
         self.certfile = certfile
         self.cafile = cafile
         self.keyfile = keyfile

--- a/tests/connections/test_gvm_connection.py
+++ b/tests/connections/test_gvm_connection.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.connections import GvmConnection, DEFAULT_TIMEOUT
+
+
+class GvmConnectionTestCase(unittest.TestCase):
+    # pylint: disable=protected-access
+    def test_init_no_args(self):
+        connection = GvmConnection()
+        self.check_for_default_values(connection)
+
+    def test_init_with_none(self):
+        connection = GvmConnection(timeout=None)
+        self.check_for_default_values(connection)
+
+    def check_for_default_values(self, gvm_connection: GvmConnection):
+        self.assertIsNone(gvm_connection._socket)
+        self.assertEqual(gvm_connection._timeout, DEFAULT_TIMEOUT)

--- a/tests/connections/test_gvm_connection.py
+++ b/tests/connections/test_gvm_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2020 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tests/connections/test_ssh_connection.py
+++ b/tests/connections/test_ssh_connection.py
@@ -18,7 +18,7 @@
 
 import unittest
 
-from gvm.connections import SSHConnection
+from gvm.connections import SSHConnection, DEFAULT_SSH_PORT
 
 
 class SSHConnectionTestCase(unittest.TestCase):
@@ -26,3 +26,4 @@ class SSHConnectionTestCase(unittest.TestCase):
         ssh_connection = SSHConnection()
 
         self.assertTrue(isinstance(ssh_connection, SSHConnection))
+        self.assertEqual(ssh_connection.port, DEFAULT_SSH_PORT)

--- a/tests/connections/test_ssh_connection.py
+++ b/tests/connections/test_ssh_connection.py
@@ -31,6 +31,16 @@ class SSHConnectionTestCase(unittest.TestCase):
     def test_init_no_args(self):
         ssh_connection = SSHConnection()
 
+        self.check_ssh_connection_for_default_values(ssh_connection)
+
+    def test_init_with_none(self):
+        ssh_connection = SSHConnection(
+            timeout=None, hostname=None, port=None, username=None, password=None
+        )
+
+        self.check_ssh_connection_for_default_values(ssh_connection)
+
+    def check_ssh_connection_for_default_values(self, ssh_connection):
         self.assertTrue(isinstance(ssh_connection, SSHConnection))
         self.assertEqual(ssh_connection.hostname, DEFAULT_HOSTNAME)
         self.assertEqual(ssh_connection.port, DEFAULT_SSH_PORT)

--- a/tests/connections/test_ssh_connection.py
+++ b/tests/connections/test_ssh_connection.py
@@ -18,7 +18,13 @@
 
 import unittest
 
-from gvm.connections import SSHConnection, DEFAULT_SSH_PORT
+from gvm.connections import (
+    SSHConnection,
+    DEFAULT_SSH_PORT,
+    DEFAULT_SSH_USERNAME,
+    DEFAULT_SSH_PASSWORD,
+    DEFAULT_HOSTNAME,
+)
 
 
 class SSHConnectionTestCase(unittest.TestCase):
@@ -26,4 +32,7 @@ class SSHConnectionTestCase(unittest.TestCase):
         ssh_connection = SSHConnection()
 
         self.assertTrue(isinstance(ssh_connection, SSHConnection))
+        self.assertEqual(ssh_connection.hostname, DEFAULT_HOSTNAME)
         self.assertEqual(ssh_connection.port, DEFAULT_SSH_PORT)
+        self.assertEqual(ssh_connection.username, DEFAULT_SSH_USERNAME)
+        self.assertEqual(ssh_connection.password, DEFAULT_SSH_PASSWORD)

--- a/tests/connections/test_ssh_connection.py
+++ b/tests/connections/test_ssh_connection.py
@@ -1,0 +1,28 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.connections import SSHConnection
+
+
+class SSHConnectionTestCase(unittest.TestCase):
+    def test_init_no_args(self):
+        ssh_connection = SSHConnection()
+
+        self.assertTrue(isinstance(ssh_connection, SSHConnection))

--- a/tests/connections/test_ssh_connection.py
+++ b/tests/connections/test_ssh_connection.py
@@ -41,7 +41,7 @@ class SSHConnectionTestCase(unittest.TestCase):
         self.check_ssh_connection_for_default_values(ssh_connection)
 
     def check_ssh_connection_for_default_values(self, ssh_connection):
-        self.assertTrue(isinstance(ssh_connection, SSHConnection))
+        self.assertIsInstance(ssh_connection, SSHConnection)
         self.assertEqual(ssh_connection.hostname, DEFAULT_HOSTNAME)
         self.assertEqual(ssh_connection.port, DEFAULT_SSH_PORT)
         self.assertEqual(ssh_connection.username, DEFAULT_SSH_USERNAME)

--- a/tests/connections/test_ssh_connection.py
+++ b/tests/connections/test_ssh_connection.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2020 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tests/connections/test_tls_connection.py
+++ b/tests/connections/test_tls_connection.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2020 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.connections import (
+    TLSConnection,
+    DEFAULT_HOSTNAME,
+    DEFAULT_GVM_PORT,
+    DEFAULT_TIMEOUT,
+)
+
+
+class TLSConnectionTestCase(unittest.TestCase):
+    # pylint: disable=protected-access
+    def test_init_no_args(self):
+        connection = TLSConnection()
+        self.check_default_values(connection)
+
+    def test_init_with_none(self):
+        connection = TLSConnection(
+            certfile=None,
+            cafile=None,
+            keyfile=None,
+            hostname=None,
+            port=None,
+            password=None,
+            timeout=None,
+        )
+        self.check_default_values(connection)
+
+    def check_default_values(self, tls_connection: TLSConnection):
+        self.assertIsNone(tls_connection.certfile)
+        self.assertIsNone(tls_connection.cafile)
+        self.assertIsNone(tls_connection.keyfile)
+        self.assertEqual(tls_connection.hostname, DEFAULT_HOSTNAME)
+        self.assertEqual(tls_connection.port, DEFAULT_GVM_PORT)
+        self.assertIsNone(tls_connection.password)
+        self.assertEqual(tls_connection._timeout, DEFAULT_TIMEOUT)

--- a/tests/connections/test_unix_socket_connection.py
+++ b/tests/connections/test_unix_socket_connection.py
@@ -24,7 +24,11 @@ import tempfile
 import threading
 import uuid
 
-from gvm.connections import UnixSocketConnection, DEFAULT_TIMEOUT
+from gvm.connections import (
+    UnixSocketConnection,
+    DEFAULT_TIMEOUT,
+    DEFAULT_UNIX_SOCKET_PATH,
+)
 from gvm.errors import GvmError
 
 
@@ -43,6 +47,7 @@ class ThreadedUnixStreamServer(
 
 
 class UnixSocketConnectionTestCase(unittest.TestCase):
+    # pylint: disable=protected-access
     def setUp(self):
         self.socketname = "%s/%s.sock" % (
             tempfile.gettempdir(),
@@ -94,6 +99,18 @@ class UnixSocketConnectionTestCase(unittest.TestCase):
         )
         with self.assertRaises(GvmError):
             self.connection.send("<gmp>/")
+
+    def test_init_no_args(self):
+        connection = UnixSocketConnection()
+        self.check_default_values(connection)
+
+    def test_init_with_none(self):
+        connection = UnixSocketConnection(path=None, timeout=None)
+        self.check_default_values(connection)
+
+    def check_default_values(self, connection: UnixSocketConnection):
+        self.assertEqual(connection._timeout, DEFAULT_TIMEOUT)
+        self.assertEqual(connection.path, DEFAULT_UNIX_SOCKET_PATH)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What**: If None is passed for any value in the constructor of SSHConnection, TLSConnection, UnixSocketConnection or GvmConnection then the default value will be used.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**: `TypeError` will be thrown if port is None, even though Port is [Optional](https://docs.python.org/3/library/typing.html#typing.Optional). Closes #320 

<!-- Why are these changes necessary? -->

**How**: I've added tests

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [X] Tests
- [X] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
