### PR TITLE
Get reports with details by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Moved tests for `SeverityLevel` Enum and `get_severity_level_from_string()` [#327](https://github.com/greenbone/python-gvm/pull/327)
 
 ### Changed
+* In `get_report()` the `details` parameter is `True` on default now. [#333](https://github.com/greenbone/python-gvm/pull/333)
+
 ### Deprecated
 ### Removed
 ### Fixed
@@ -23,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the `get_x_from_string()` functions to `latest` [#308](https://github.com/greenbone/python-gvm/pull/308)
 * Added the `ReportFormatType` that can be used instead of a report_format_id [#311](https://github.com/greenbone/python-gvm/pull/311)
 * Added tests for constructor of SSHConnection, TLSConnection, UnixSocketConnection and GvmConnection [#321](https://github.com/greenbone/python-gvm/pull/321)
-* Added information message to `get_report()` if called without `details`. [#333](https://github.com/greenbone/python-gvm/pull/333)
 
 ### Fixed
 * Corrected `seconds_active` parameter to `days_active` for notes and overrides. [#307](https://github.com/greenbone/python-gvm/pull/307)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Added the `get_x_from_string()` functions to `latest` [#308](https://github.com/greenbone/python-gvm/pull/308)
 * Added the `ReportFormatType` that can be used instead of a report_format_id [#311](https://github.com/greenbone/python-gvm/pull/311)
 * Added tests for constructor of SSHConnection, TLSConnection, UnixSocketConnection and GvmConnection [#321](https://github.com/greenbone/python-gvm/pull/321)
+* Added information message to `get_report()` if called without `details`. [#333](https://github.com/greenbone/python-gvm/pull/333)
 
 ### Fixed
 * Corrected `seconds_active` parameter to `days_active` for notes and overrides. [#307](https://github.com/greenbone/python-gvm/pull/307)

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -3774,6 +3774,12 @@ class GmpV7Mixin(GvmProtocol):
         if ignore_pagination is not None:
             cmd.set_attribute("ignore_pagination", _to_bool(ignore_pagination))
 
+        if not details:
+            logger.info(
+                msg='Your report will be without report details.'
+                'If you want a report with details, please'
+                'pass the details=True to the function call.'
+            )
         if details is not None:
             cmd.set_attribute("details", _to_bool(details))
 

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -3733,7 +3733,7 @@ class GmpV7Mixin(GvmProtocol):
         delta_report_id: Optional[str] = None,
         report_format_id: Optional[Union[str, ReportFormatType]] = None,
         ignore_pagination: Optional[bool] = None,
-        details: Optional[bool] = None
+        details: Optional[bool] = True
     ) -> Any:
         """Request a single report
 
@@ -3775,10 +3775,7 @@ class GmpV7Mixin(GvmProtocol):
         if ignore_pagination is not None:
             cmd.set_attribute("ignore_pagination", _to_bool(ignore_pagination))
 
-        if details is False:
-            cmd.set_attribute("details", _to_bool(details))
-        else:
-            cmd.set_attribute("details", _to_bool(True))
+        cmd.set_attribute("details", _to_bool(details))
 
         return self._send_xml_command(cmd)
 

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -3747,6 +3747,7 @@ class GmpV7Mixin(GvmProtocol):
             ignore_pagination: Whether to ignore the filter terms "first" and
                 "rows".
             details: Request additional report information details
+                     defaults to True
 
         Returns:
             The response. See :py:meth:`send_command` for details.
@@ -3774,14 +3775,10 @@ class GmpV7Mixin(GvmProtocol):
         if ignore_pagination is not None:
             cmd.set_attribute("ignore_pagination", _to_bool(ignore_pagination))
 
-        if not details:
-            logger.info(
-                msg='Your report will be without report details.'
-                'If you want a report with details, please'
-                'pass the details=True to the function call.'
-            )
-        if details is not None:
+        if details is False:
             cmd.set_attribute("details", _to_bool(details))
+        else:
+            cmd.set_attribute("details", _to_bool(True))
 
         return self._send_xml_command(cmd)
 

--- a/gvm/protocols/gmpv7/gmpv7.py
+++ b/gvm/protocols/gmpv7/gmpv7.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 - 2019 Greenbone Networks GmbH
+# Copyright (C) 2018 - 2020 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tests/protocols/gmpv7/testcmds/test_get_report.py
+++ b/tests/protocols/gmpv7/testcmds/test_get_report.py
@@ -18,6 +18,8 @@
 
 import unittest
 
+from unittest.mock import patch
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.gmpv7 import (
     ReportFormatType,
@@ -91,6 +93,26 @@ class GmpGetReportTestCase:
 
         self.connection.send.has_been_called_with(
             '<get_reports report_id="r1" details="1"/>'
+        )
+
+        self.gmp.get_report(report_id='r1', details=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_reports report_id="r1" details="0"/>'
+        )
+
+    @patch('gvm.protocols.gmpv7.gmpv7.logger')
+    def test_get_report_without_details(self, logger_mock):
+        self.gmp.get_report(report_id='r1')
+
+        logger_mock.info.assert_called_with(
+            msg='Your report will be without report details.'
+            'If you want a report with details, please'
+            'pass the details=True to the function call.'
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_reports report_id="r1"/>'
         )
 
         self.gmp.get_report(report_id='r1', details=False)

--- a/tests/protocols/gmpv7/testcmds/test_get_report.py
+++ b/tests/protocols/gmpv7/testcmds/test_get_report.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2018-2020 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tests/protocols/gmpv7/testcmds/test_get_report.py
+++ b/tests/protocols/gmpv7/testcmds/test_get_report.py
@@ -115,10 +115,18 @@ class GmpGetReportTestCase:
             '<get_reports report_id="r1"/>'
         )
 
+        logger_mock.reset_mock()
+
         self.gmp.get_report(report_id='r1', details=False)
 
         self.connection.send.has_been_called_with(
             '<get_reports report_id="r1" details="0"/>'
+        )
+
+        logger_mock.info.assert_called_with(
+            msg='Your report will be without report details.'
+            'If you want a report with details, please'
+            'pass the details=True to the function call.'
         )
 
 

--- a/tests/protocols/gmpv7/testcmds/test_get_report.py
+++ b/tests/protocols/gmpv7/testcmds/test_get_report.py
@@ -18,8 +18,6 @@
 
 import unittest
 
-from unittest.mock import patch
-
 from gvm.errors import RequiredArgument
 from gvm.protocols.gmpv7 import (
     ReportFormatType,
@@ -39,21 +37,21 @@ class GmpGetReportTestCase:
         self.gmp.get_report(report_id='r1', filter='name=foo')
 
         self.connection.send.has_been_called_with(
-            '<get_reports report_id="r1" filter="name=foo"/>'
+            '<get_reports report_id="r1" filter="name=foo" details="1"/>'
         )
 
     def test_get_report_with_filter_id(self):
         self.gmp.get_report(report_id='r1', filter_id='f1')
 
         self.connection.send.has_been_called_with(
-            '<get_reports report_id="r1" filt_id="f1"/>'
+            '<get_reports report_id="r1" filt_id="f1" details="1"/>'
         )
 
     def test_get_report_with_report_format_id(self):
         self.gmp.get_report(report_id='r1', report_format_id='bar')
 
         self.connection.send.has_been_called_with(
-            '<get_reports report_id="r1" format_id="bar"/>'
+            '<get_reports report_id="r1" format_id="bar" details="1"/>'
         )
 
     def test_get_report_with_report_format_type(self):
@@ -63,7 +61,7 @@ class GmpGetReportTestCase:
         report_format_id = get_report_format_id_from_string('txt').value
 
         self.connection.send.has_been_called_with(
-            '<get_reports report_id="r1" format_id="{}"/>'.format(
+            '<get_reports report_id="r1" format_id="{}" details="1"/>'.format(
                 report_format_id
             )
         )
@@ -72,20 +70,20 @@ class GmpGetReportTestCase:
         self.gmp.get_report(report_id='r1', delta_report_id='r2')
 
         self.connection.send.has_been_called_with(
-            '<get_reports report_id="r1" delta_report_id="r2"/>'
+            '<get_reports report_id="r1" delta_report_id="r2" details="1"/>'
         )
 
     def test_get_report_with_ignore_pagination(self):
         self.gmp.get_report(report_id='r1', ignore_pagination=True)
 
         self.connection.send.has_been_called_with(
-            '<get_reports report_id="r1" ignore_pagination="1"/>'
+            '<get_reports report_id="r1" ignore_pagination="1" details="1"/>'
         )
 
         self.gmp.get_report(report_id='r1', ignore_pagination=False)
 
         self.connection.send.has_been_called_with(
-            '<get_reports report_id="r1" ignore_pagination="0"/>'
+            '<get_reports report_id="r1" ignore_pagination="0" details="1"/>'
         )
 
     def test_get_report_with_details(self):
@@ -99,34 +97,6 @@ class GmpGetReportTestCase:
 
         self.connection.send.has_been_called_with(
             '<get_reports report_id="r1" details="0"/>'
-        )
-
-    @patch('gvm.protocols.gmpv7.gmpv7.logger')
-    def test_get_report_without_details(self, logger_mock):
-        self.gmp.get_report(report_id='r1')
-
-        logger_mock.info.assert_called_with(
-            msg='Your report will be without report details.'
-            'If you want a report with details, please'
-            'pass the details=True to the function call.'
-        )
-
-        self.connection.send.has_been_called_with(
-            '<get_reports report_id="r1"/>'
-        )
-
-        logger_mock.reset_mock()
-
-        self.gmp.get_report(report_id='r1', details=False)
-
-        self.connection.send.has_been_called_with(
-            '<get_reports report_id="r1" details="0"/>'
-        )
-
-        logger_mock.info.assert_called_with(
-            msg='Your report will be without report details.'
-            'If you want a report with details, please'
-            'pass the details=True to the function call.'
         )
 
 


### PR DESCRIPTION
**What**:

In `get_report` is `details` parameter is `True` on default now ...

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

It is frequently asked, why the report does not contain any information.

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
