### PR TITLE
Add allow_simultaneous_ips param for targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
-* Added allow_simult_ips_same_host param for targets [#380](https://github.com/greenbone/python-gvm/pull/380)
+* Added allow_simultaneous_ips param for targets [#380](https://github.com/greenbone/python-gvm/pull/380)
 
 ### Changed
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+* Added allow_simult_ips_same_host param for targets [#380](https://github.com/greenbone/python-gvm/pull/380)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/gvm/protocols/gmpv214/gmpv214.py
+++ b/gvm/protocols/gmpv214/gmpv214.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020 Greenbone Networks GmbH
+# Copyright (C) 2020-2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/gvm/protocols/gmpv214/gmpv214.py
+++ b/gvm/protocols/gmpv214/gmpv214.py
@@ -34,7 +34,7 @@ from gvm.xml import XmlCommand
 from gvm.protocols.gmpv7.gmpv7 import _to_comma_list, _to_bool
 
 from gvm.connections import GvmConnection
-from gvm.errors import RequiredArgument
+from gvm.errors import InvalidArgumentType, RequiredArgument
 
 from gvm.protocols.base import GvmProtocol
 
@@ -226,6 +226,132 @@ class GmpV214Mixin(GvmProtocol):
 
         return self._send_xml_command(cmd)
 
+    def create_target(
+        self,
+        name: str,
+        *,
+        make_unique: Optional[bool] = None,
+        asset_hosts_filter: Optional[str] = None,
+        hosts: Optional[List[str]] = None,
+        comment: Optional[str] = None,
+        exclude_hosts: Optional[List[str]] = None,
+        ssh_credential_id: Optional[str] = None,
+        ssh_credential_port: Optional[int] = None,
+        smb_credential_id: Optional[str] = None,
+        esxi_credential_id: Optional[str] = None,
+        snmp_credential_id: Optional[str] = None,
+        alive_test: Optional[AliveTest] = None,
+        allow_simult_ips_same_host: Optional[bool] = None,
+        reverse_lookup_only: Optional[bool] = None,
+        reverse_lookup_unify: Optional[bool] = None,
+        port_range: Optional[str] = None,
+        port_list_id: Optional[str] = None,
+    ) -> Any:
+        """Create a new target
+
+        Arguments:
+            name: Name of the target
+            make_unique: Append a unique suffix if the name already exists
+            asset_hosts_filter: Filter to select target host from assets hosts
+            hosts: List of hosts addresses to scan
+            exclude_hosts: List of hosts addresses to exclude from scan
+            comment: Comment for the target
+            ssh_credential_id: UUID of a ssh credential to use on target
+            ssh_credential_port: The port to use for ssh credential
+            smb_credential_id: UUID of a smb credential to use on target
+            snmp_credential_id: UUID of a snmp credential to use on target
+            esxi_credential_id: UUID of a esxi credential to use on target
+            alive_test: Which alive test to use
+            allow_simult_ips_same_host: Whether to scan multiple IPs of the
+                same host simultaneously
+            reverse_lookup_only: Whether to scan only hosts that have names
+            reverse_lookup_unify: Whether to scan only one IP when multiple IPs
+                have the same name.
+            port_range: Port range for the target
+            port_list_id: UUID of the port list to use on target
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not name:
+            raise RequiredArgument(
+                function=self.create_target.__name__, argument='name'
+            )
+
+        cmd = XmlCommand("create_target")
+        _xmlname = cmd.add_element("name", name)
+
+        if make_unique is not None:
+            _xmlname.add_element("make_unique", _to_bool(make_unique))
+
+        if asset_hosts_filter:
+            cmd.add_element(
+                "asset_hosts", attrs={"filter": str(asset_hosts_filter)}
+            )
+        elif hosts:
+            cmd.add_element("hosts", _to_comma_list(hosts))
+        else:
+            raise RequiredArgument(
+                function=self.create_target.__name__,
+                argument='hosts or asset_hosts_filter',
+            )
+
+        if comment:
+            cmd.add_element("comment", comment)
+
+        if exclude_hosts:
+            cmd.add_element("exclude_hosts", _to_comma_list(exclude_hosts))
+
+        if ssh_credential_id:
+            _xmlssh = cmd.add_element(
+                "ssh_credential", attrs={"id": ssh_credential_id}
+            )
+            if ssh_credential_port:
+                _xmlssh.add_element("port", str(ssh_credential_port))
+
+        if smb_credential_id:
+            cmd.add_element("smb_credential", attrs={"id": smb_credential_id})
+
+        if esxi_credential_id:
+            cmd.add_element("esxi_credential", attrs={"id": esxi_credential_id})
+
+        if snmp_credential_id:
+            cmd.add_element("snmp_credential", attrs={"id": snmp_credential_id})
+
+        if alive_test:
+            if not isinstance(alive_test, AliveTest):
+                raise InvalidArgumentType(
+                    function=self.create_target.__name__,
+                    argument='alive_test',
+                    arg_type=AliveTest.__name__,
+                )
+
+            cmd.add_element("alive_tests", alive_test.value)
+
+        if allow_simult_ips_same_host is not None:
+            cmd.add_element(
+                "allow_simult_ips_same_host",
+                _to_bool(allow_simult_ips_same_host),
+            )
+
+        if reverse_lookup_only is not None:
+            cmd.add_element(
+                "reverse_lookup_only", _to_bool(reverse_lookup_only)
+            )
+
+        if reverse_lookup_unify is not None:
+            cmd.add_element(
+                "reverse_lookup_unify", _to_bool(reverse_lookup_unify)
+            )
+
+        if port_range:
+            cmd.add_element("port_range", port_range)
+
+        if port_list_id:
+            cmd.add_element("port_list", attrs={"id": port_list_id})
+
+        return self._send_xml_command(cmd)
+
     def modify_note(
         self,
         note_id: str,
@@ -386,6 +512,118 @@ class GmpV214Mixin(GvmProtocol):
                     self.get_protocol_version()[1],
                 )
             )
+
+        return self._send_xml_command(cmd)
+
+    def modify_target(
+        self,
+        target_id: str,
+        *,
+        name: Optional[str] = None,
+        comment: Optional[str] = None,
+        hosts: Optional[List[str]] = None,
+        exclude_hosts: Optional[List[str]] = None,
+        ssh_credential_id: Optional[str] = None,
+        ssh_credential_port: Optional[bool] = None,
+        smb_credential_id: Optional[str] = None,
+        esxi_credential_id: Optional[str] = None,
+        snmp_credential_id: Optional[str] = None,
+        alive_test: Optional[AliveTest] = None,
+        allow_simult_ips_same_host: Optional[bool] = None,
+        reverse_lookup_only: Optional[bool] = None,
+        reverse_lookup_unify: Optional[bool] = None,
+        port_list_id: Optional[str] = None,
+    ) -> Any:
+        """Modifies an existing target.
+
+        Arguments:
+            target_id: ID of target to modify.
+            comment: Comment on target.
+            name: Name of target.
+            hosts: List of target hosts.
+            exclude_hosts: A list of hosts to exclude.
+            ssh_credential_id: UUID of SSH credential to use on target.
+            ssh_credential_port: The port to use for ssh credential
+            smb_credential_id: UUID of SMB credential to use on target.
+            esxi_credential_id: UUID of ESXi credential to use on target.
+            snmp_credential_id: UUID of SNMP credential to use on target.
+            port_list_id: UUID of port list describing ports to scan.
+            alive_test: Which alive tests to use.
+            allow_simult_ips_same_host: Whether to scan multiple IPs of the
+                same host simultaneously
+            reverse_lookup_only: Whether to scan only hosts that have names.
+            reverse_lookup_unify: Whether to scan only one IP when multiple IPs
+                have the same name.
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not target_id:
+            raise RequiredArgument(
+                function=self.modify_target.__name__, argument='target_id'
+            )
+
+        cmd = XmlCommand("modify_target")
+        cmd.set_attribute("target_id", target_id)
+
+        if comment:
+            cmd.add_element("comment", comment)
+
+        if name:
+            cmd.add_element("name", name)
+
+        if hosts:
+            cmd.add_element("hosts", _to_comma_list(hosts))
+            if exclude_hosts is None:
+                exclude_hosts = ['']
+
+        if exclude_hosts:
+            cmd.add_element("exclude_hosts", _to_comma_list(exclude_hosts))
+
+        if alive_test:
+            if not isinstance(alive_test, AliveTest):
+                raise InvalidArgumentType(
+                    function=self.modify_target.__name__,
+                    argument='alive_test',
+                    arg_type=AliveTest.__name__,
+                )
+            cmd.add_element("alive_tests", alive_test.value)
+
+        if ssh_credential_id:
+            _xmlssh = cmd.add_element(
+                "ssh_credential", attrs={"id": ssh_credential_id}
+            )
+
+            if ssh_credential_port:
+                _xmlssh.add_element("port", str(ssh_credential_port))
+
+        if smb_credential_id:
+            cmd.add_element("smb_credential", attrs={"id": smb_credential_id})
+
+        if esxi_credential_id:
+            cmd.add_element("esxi_credential", attrs={"id": esxi_credential_id})
+
+        if snmp_credential_id:
+            cmd.add_element("snmp_credential", attrs={"id": snmp_credential_id})
+
+        if allow_simult_ips_same_host is not None:
+            cmd.add_element(
+                "allow_simult_ips_same_host",
+                _to_bool(allow_simult_ips_same_host),
+            )
+
+        if reverse_lookup_only is not None:
+            cmd.add_element(
+                "reverse_lookup_only", _to_bool(reverse_lookup_only)
+            )
+
+        if reverse_lookup_unify is not None:
+            cmd.add_element(
+                "reverse_lookup_unify", _to_bool(reverse_lookup_unify)
+            )
+
+        if port_list_id:
+            cmd.add_element("port_list", attrs={"id": port_list_id})
 
         return self._send_xml_command(cmd)
 

--- a/gvm/protocols/gmpv214/gmpv214.py
+++ b/gvm/protocols/gmpv214/gmpv214.py
@@ -241,7 +241,7 @@ class GmpV214Mixin(GvmProtocol):
         esxi_credential_id: Optional[str] = None,
         snmp_credential_id: Optional[str] = None,
         alive_test: Optional[AliveTest] = None,
-        allow_simult_ips_same_host: Optional[bool] = None,
+        allow_simultaneous_ips: Optional[bool] = None,
         reverse_lookup_only: Optional[bool] = None,
         reverse_lookup_unify: Optional[bool] = None,
         port_range: Optional[str] = None,
@@ -262,7 +262,7 @@ class GmpV214Mixin(GvmProtocol):
             snmp_credential_id: UUID of a snmp credential to use on target
             esxi_credential_id: UUID of a esxi credential to use on target
             alive_test: Which alive test to use
-            allow_simult_ips_same_host: Whether to scan multiple IPs of the
+            allow_simultaneous_ips: Whether to scan multiple IPs of the
                 same host simultaneously
             reverse_lookup_only: Whether to scan only hosts that have names
             reverse_lookup_unify: Whether to scan only one IP when multiple IPs
@@ -328,10 +328,10 @@ class GmpV214Mixin(GvmProtocol):
 
             cmd.add_element("alive_tests", alive_test.value)
 
-        if allow_simult_ips_same_host is not None:
+        if allow_simultaneous_ips is not None:
             cmd.add_element(
-                "allow_simult_ips_same_host",
-                _to_bool(allow_simult_ips_same_host),
+                "allow_simultaneous_ips",
+                _to_bool(allow_simultaneous_ips),
             )
 
         if reverse_lookup_only is not None:
@@ -529,7 +529,7 @@ class GmpV214Mixin(GvmProtocol):
         esxi_credential_id: Optional[str] = None,
         snmp_credential_id: Optional[str] = None,
         alive_test: Optional[AliveTest] = None,
-        allow_simult_ips_same_host: Optional[bool] = None,
+        allow_simultaneous_ips: Optional[bool] = None,
         reverse_lookup_only: Optional[bool] = None,
         reverse_lookup_unify: Optional[bool] = None,
         port_list_id: Optional[str] = None,
@@ -549,7 +549,7 @@ class GmpV214Mixin(GvmProtocol):
             snmp_credential_id: UUID of SNMP credential to use on target.
             port_list_id: UUID of port list describing ports to scan.
             alive_test: Which alive tests to use.
-            allow_simult_ips_same_host: Whether to scan multiple IPs of the
+            allow_simultaneous_ips: Whether to scan multiple IPs of the
                 same host simultaneously
             reverse_lookup_only: Whether to scan only hosts that have names.
             reverse_lookup_unify: Whether to scan only one IP when multiple IPs
@@ -606,10 +606,10 @@ class GmpV214Mixin(GvmProtocol):
         if snmp_credential_id:
             cmd.add_element("snmp_credential", attrs={"id": snmp_credential_id})
 
-        if allow_simult_ips_same_host is not None:
+        if allow_simultaneous_ips is not None:
             cmd.add_element(
-                "allow_simult_ips_same_host",
-                _to_bool(allow_simult_ips_same_host),
+                "allow_simultaneous_ips",
+                _to_bool(allow_simultaneous_ips),
             )
 
         if reverse_lookup_only is not None:

--- a/tests/protocols/gmpv214/test_new_gmpv214.py
+++ b/tests/protocols/gmpv214/test_new_gmpv214.py
@@ -28,11 +28,19 @@ class Gmpv214CreateOverrideTestCase(GmpCreateOverrideTestCase, Gmpv214TestCase):
     pass
 
 
+class Gmpv214CreateTargetTestCase(GmpCreateTargetTestCase, Gmpv214TestCase):
+    pass
+
+
 class Gmpv214ModifyNoteTestCase(GmpModifyNoteTestCase, Gmpv214TestCase):
     pass
 
 
 class Gmpv214ModifyOverrideTestCase(GmpModifyOverrideTestCase, Gmpv214TestCase):
+    pass
+
+
+class Gmpv214ModifyTargetTestCase(GmpModifyTargetTestCase, Gmpv214TestCase):
     pass
 
 

--- a/tests/protocols/gmpv214/test_new_gmpv214.py
+++ b/tests/protocols/gmpv214/test_new_gmpv214.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020 Greenbone Networks GmbH
+# Copyright (C) 2020-2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tests/protocols/gmpv214/testcmds/__init__.py
+++ b/tests/protocols/gmpv214/testcmds/__init__.py
@@ -20,6 +20,8 @@
 
 from .test_create_note import GmpCreateNoteTestCase
 from .test_create_override import GmpCreateOverrideTestCase
+from .test_create_target import GmpCreateTargetTestCase
 from .test_modify_note import GmpModifyNoteTestCase
 from .test_modify_override import GmpModifyOverrideTestCase
+from .test_modify_target import GmpModifyTargetTestCase
 from .test_modify_user import GmpModifyUserTestCase

--- a/tests/protocols/gmpv214/testcmds/__init__.py
+++ b/tests/protocols/gmpv214/testcmds/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding utf-8 -*-
-# Copyright (C) 2020 Greenbone Networks GmbH
+# Copyright (C) 2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier GPL-3.0-or-later
 #

--- a/tests/protocols/gmpv214/testcmds/__init__.py
+++ b/tests/protocols/gmpv214/testcmds/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding utf-8 -*-
-# Copyright (C) 2021 Greenbone Networks GmbH
+# Copyright (C) 2020-2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier GPL-3.0-or-later
 #

--- a/tests/protocols/gmpv214/testcmds/test_create_target.py
+++ b/tests/protocols/gmpv214/testcmds/test_create_target.py
@@ -170,32 +170,28 @@ class GmpCreateTargetTestCase:
         with self.assertRaises(InvalidArgumentType):
             self.gmp.create_target('foo', hosts=['foo'], alive_test='foo')
 
-    def test_create_target_with_allow_simult_ips_same_host(self):
+    def test_create_target_with_allow_simultaneous_ips(self):
         self.gmp.create_target(
-            'foo',
-            hosts=['foo'],
-            allow_simult_ips_same_host=True
+            'foo', hosts=['foo'], allow_simultaneous_ips=True
         )
 
         self.connection.send.has_been_called_with(
             '<create_target>'
             '<name>foo</name>'
             '<hosts>foo</hosts>'
-            '<allow_simult_ips_same_host>1</allow_simult_ips_same_host>'
+            '<allow_simultaneous_ips>1</allow_simultaneous_ips>'
             '</create_target>'
         )
 
         self.gmp.create_target(
-            'foo',
-            hosts=['foo'],
-            allow_simult_ips_same_host=False
+            'foo', hosts=['foo'], allow_simultaneous_ips=False
         )
 
         self.connection.send.has_been_called_with(
             '<create_target>'
             '<name>foo</name>'
             '<hosts>foo</hosts>'
-            '<allow_simult_ips_same_host>0</allow_simult_ips_same_host>'
+            '<allow_simultaneous_ips>0</allow_simultaneous_ips>'
             '</create_target>'
         )
 

--- a/tests/protocols/gmpv214/testcmds/test_create_target.py
+++ b/tests/protocols/gmpv214/testcmds/test_create_target.py
@@ -1,0 +1,268 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import RequiredArgument, InvalidArgumentType
+
+from gvm.protocols.gmpv208 import AliveTest
+
+
+class GmpCreateTargetTestCase:
+    def test_create_target_with_make_unique(self):
+        self.gmp.create_target('foo', make_unique=True, hosts=['foo', 'bar'])
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo<make_unique>1</make_unique></name>'
+            '<hosts>foo,bar</hosts>'
+            '</create_target>'
+        )
+
+        self.gmp.create_target('foo', make_unique=False, hosts=['foo', 'bar'])
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo<make_unique>0</make_unique></name>'
+            '<hosts>foo,bar</hosts>'
+            '</create_target>'
+        )
+
+    def test_create_target_missing_name(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_target(None, hosts=['foo'])
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_target(name=None, hosts=['foo'])
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_target('', hosts=['foo'])
+
+    def test_create_target_with_asset_hosts_filter(self):
+        self.gmp.create_target('foo', asset_hosts_filter='name=foo')
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<asset_hosts filter="name=foo"/>'
+            '</create_target>'
+        )
+
+    def test_create_target_missing_hosts(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_target(name='foo')
+
+    def test_create_target_with_comment(self):
+        self.gmp.create_target('foo', hosts=['foo'], comment='bar')
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<comment>bar</comment>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_exclude_hosts(self):
+        self.gmp.create_target(
+            'foo', hosts=['foo', 'bar'], exclude_hosts=['bar', 'ipsum']
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo,bar</hosts>'
+            '<exclude_hosts>bar,ipsum</exclude_hosts>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_ssh_credential(self):
+        self.gmp.create_target('foo', hosts=['foo'], ssh_credential_id='c1')
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<ssh_credential id="c1"/>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_ssh_credential_port(self):
+        self.gmp.create_target(
+            'foo',
+            hosts=['foo'],
+            ssh_credential_id='c1',
+            ssh_credential_port=123,
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<ssh_credential id="c1">'
+            '<port>123</port>'
+            '</ssh_credential>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_smb_credential_id(self):
+        self.gmp.create_target('foo', hosts=['foo'], smb_credential_id='c1')
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<smb_credential id="c1"/>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_esxi_credential_id(self):
+        self.gmp.create_target('foo', hosts=['foo'], esxi_credential_id='c1')
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<esxi_credential id="c1"/>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_snmp_credential_id(self):
+        self.gmp.create_target('foo', hosts=['foo'], snmp_credential_id='c1')
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<snmp_credential id="c1"/>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_alive_tests(self):
+        self.gmp.create_target(
+            'foo', hosts=['foo'], alive_test=AliveTest.ICMP_PING
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<alive_tests>ICMP Ping</alive_tests>'
+            '</create_target>'
+        )
+
+    def test_create_target_invalid_alive_tests(self):
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.create_target('foo', hosts=['foo'], alive_test='foo')
+
+    def test_create_target_with_allow_simult_ips_same_host(self):
+        self.gmp.create_target(
+            'foo',
+            hosts=['foo'],
+            allow_simult_ips_same_host=True
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<allow_simult_ips_same_host>1</allow_simult_ips_same_host>'
+            '</create_target>'
+        )
+
+        self.gmp.create_target(
+            'foo',
+            hosts=['foo'],
+            allow_simult_ips_same_host=False
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<allow_simult_ips_same_host>0</allow_simult_ips_same_host>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_reverse_lookup_only(self):
+        self.gmp.create_target('foo', hosts=['foo'], reverse_lookup_only=True)
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<reverse_lookup_only>1</reverse_lookup_only>'
+            '</create_target>'
+        )
+
+        self.gmp.create_target('foo', hosts=['foo'], reverse_lookup_only=False)
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<reverse_lookup_only>0</reverse_lookup_only>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_reverse_lookup_unify(self):
+        self.gmp.create_target('foo', hosts=['foo'], reverse_lookup_unify=True)
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<reverse_lookup_unify>1</reverse_lookup_unify>'
+            '</create_target>'
+        )
+
+        self.gmp.create_target('foo', hosts=['foo'], reverse_lookup_unify=False)
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<reverse_lookup_unify>0</reverse_lookup_unify>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_port_range(self):
+        self.gmp.create_target('foo', hosts=['foo'], port_range='bar')
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<port_range>bar</port_range>'
+            '</create_target>'
+        )
+
+    def test_create_target_with_port_list_id(self):
+        self.gmp.create_target('foo', hosts=['foo'], port_list_id='pl1')
+
+        self.connection.send.has_been_called_with(
+            '<create_target>'
+            '<name>foo</name>'
+            '<hosts>foo</hosts>'
+            '<port_list id="pl1"/>'
+            '</create_target>'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmpv214/testcmds/test_create_target.py
+++ b/tests/protocols/gmpv214/testcmds/test_create_target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tests/protocols/gmpv214/testcmds/test_modify_target.py
+++ b/tests/protocols/gmpv214/testcmds/test_modify_target.py
@@ -1,0 +1,219 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import RequiredArgument, InvalidArgumentType
+
+from gvm.protocols.gmpv208 import AliveTest
+
+
+class GmpModifyTargetTestCase:
+    def test_modify_target(self):
+        self.gmp.modify_target(target_id='t1')
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1"/>'
+        )
+
+    def test_modify_target_missing_target_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_target(target_id=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_target(target_id='')
+
+    def test_modify_target_with_comment(self):
+        self.gmp.modify_target(target_id='t1', comment='foo')
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<comment>foo</comment>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_hosts(self):
+        self.gmp.modify_target(target_id='t1', hosts=['foo'])
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<hosts>foo</hosts>'
+            '<exclude_hosts></exclude_hosts>'
+            '</modify_target>'
+        )
+
+        self.gmp.modify_target(target_id='t1', hosts=['foo', 'bar'])
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<hosts>foo,bar</hosts>'
+            '<exclude_hosts></exclude_hosts>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_name(self):
+        self.gmp.modify_target(target_id='t1', name='foo')
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<name>foo</name>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_exclude_hosts(self):
+        self.gmp.modify_target(target_id='t1', exclude_hosts=['foo'])
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<exclude_hosts>foo</exclude_hosts>'
+            '</modify_target>'
+        )
+
+        self.gmp.modify_target(target_id='t1', exclude_hosts=['foo', 'bar'])
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<exclude_hosts>foo,bar</exclude_hosts>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_ssh_credential(self):
+        self.gmp.modify_target(target_id='t1', ssh_credential_id='c1')
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<ssh_credential id="c1"/>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_ssh_credential_port(self):
+        self.gmp.modify_target(
+            target_id='t1', ssh_credential_id='c1', ssh_credential_port=123
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<ssh_credential id="c1">'
+            '<port>123</port>'
+            '</ssh_credential>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_smb_credential_id(self):
+        self.gmp.modify_target(target_id='t1', smb_credential_id='c1')
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<smb_credential id="c1"/>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_esxi_credential_id(self):
+        self.gmp.modify_target(target_id='t1', esxi_credential_id='c1')
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<esxi_credential id="c1"/>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_snmp_credential_id(self):
+        self.gmp.modify_target(target_id='t1', snmp_credential_id='c1')
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<snmp_credential id="c1"/>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_alive_tests(self):
+        self.gmp.modify_target(target_id='t1', alive_test=AliveTest.ICMP_PING)
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<alive_tests>ICMP Ping</alive_tests>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_invalid_alive_tests(self):
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_target(target_id='t1', alive_test='foo')
+
+    def test_modify_target_with_allow_simult_ips_same_host(self):
+        self.gmp.modify_target(target_id='t1', allow_simult_ips_same_host=True)
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<allow_simult_ips_same_host>1</allow_simult_ips_same_host>'
+            '</modify_target>'
+        )
+
+        self.gmp.modify_target(target_id='t1', allow_simult_ips_same_host=False)
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<allow_simult_ips_same_host>0</allow_simult_ips_same_host>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_reverse_lookup_only(self):
+        self.gmp.modify_target(target_id='t1', reverse_lookup_only=True)
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<reverse_lookup_only>1</reverse_lookup_only>'
+            '</modify_target>'
+        )
+
+        self.gmp.modify_target(target_id='t1', reverse_lookup_only=False)
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<reverse_lookup_only>0</reverse_lookup_only>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_reverse_lookup_unify(self):
+        self.gmp.modify_target(target_id='t1', reverse_lookup_unify=True)
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<reverse_lookup_unify>1</reverse_lookup_unify>'
+            '</modify_target>'
+        )
+
+        self.gmp.modify_target(target_id='t1', reverse_lookup_unify=False)
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<reverse_lookup_unify>0</reverse_lookup_unify>'
+            '</modify_target>'
+        )
+
+    def test_modify_target_with_port_list_id(self):
+        self.gmp.modify_target(target_id='t1', port_list_id='pl1')
+
+        self.connection.send.has_been_called_with(
+            '<modify_target target_id="t1">'
+            '<port_list id="pl1"/>'
+            '</modify_target>'
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/protocols/gmpv214/testcmds/test_modify_target.py
+++ b/tests/protocols/gmpv214/testcmds/test_modify_target.py
@@ -154,20 +154,20 @@ class GmpModifyTargetTestCase:
         with self.assertRaises(InvalidArgumentType):
             self.gmp.modify_target(target_id='t1', alive_test='foo')
 
-    def test_modify_target_with_allow_simult_ips_same_host(self):
-        self.gmp.modify_target(target_id='t1', allow_simult_ips_same_host=True)
+    def test_modify_target_with_allow_simultaneous_ips(self):
+        self.gmp.modify_target(target_id='t1', allow_simultaneous_ips=True)
 
         self.connection.send.has_been_called_with(
             '<modify_target target_id="t1">'
-            '<allow_simult_ips_same_host>1</allow_simult_ips_same_host>'
+            '<allow_simultaneous_ips>1</allow_simultaneous_ips>'
             '</modify_target>'
         )
 
-        self.gmp.modify_target(target_id='t1', allow_simult_ips_same_host=False)
+        self.gmp.modify_target(target_id='t1', allow_simultaneous_ips=False)
 
         self.connection.send.has_been_called_with(
             '<modify_target target_id="t1">'
-            '<allow_simult_ips_same_host>0</allow_simult_ips_same_host>'
+            '<allow_simultaneous_ips>0</allow_simultaneous_ips>'
             '</modify_target>'
         )
 

--- a/tests/protocols/gmpv214/testcmds/test_modify_target.py
+++ b/tests/protocols/gmpv214/testcmds/test_modify_target.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018 Greenbone Networks GmbH
+# Copyright (C) 2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #


### PR DESCRIPTION
**What**:
The create_target and modify_target commands now have an optional
parameter to set whether scanning multiple IPs per host simultaneously
is allowed.
The tests for the commands are updated accordingly.

**Why**:
To make the new option usable in python-gvm.

**How**:
Tested by running a program that uses the two commands, including the
new option.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [x] Documentation
