### PR TITLE
Add protocol version "next" and GMP 21.04 doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+* Added protocol version "next" and GMP 21.04 doc [#384](https://github.com/greenbone/python-gvm/pull/384)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/docs/api/gmpv214.rst
+++ b/docs/api/gmpv214.rst
@@ -1,0 +1,92 @@
+.. _gmpv214:
+
+GMP v21.4
+^^^^^^^^^
+
+.. automodule:: gvm.protocols.gmpv214
+
+Enums
+-----
+
+.. autoclass:: AlertCondition
+    :members:
+    :undoc-members:
+
+.. autoclass:: AlertEvent
+    :members:
+    :undoc-members:
+
+.. autoclass:: AlertMethod
+    :members:
+    :undoc-members:
+
+.. autoclass:: AliveTest
+    :members:
+    :undoc-members:
+
+.. autoclass:: AssetType
+    :members:
+    :undoc-members:
+
+.. autoclass:: CredentialFormat
+    :members:
+    :undoc-members:
+
+.. autoclass:: CredentialType
+    :members:
+    :undoc-members:
+
+.. autoclass:: EntityType
+    :members:
+    :undoc-members:
+
+.. autoclass:: FeedType
+    :members:
+    :undoc-members:
+
+.. autoclass:: FilterType
+    :members:
+    :undoc-members:
+
+.. autoclass:: HostsOrdering
+    :members:
+    :undoc-members:
+
+.. autoclass:: InfoType
+    :members:
+    :undoc-members:
+
+.. autoclass:: PermissionSubjectType
+    :members:
+    :undoc-members:
+
+.. autoclass:: ScannerType
+    :members:
+    :undoc-members:
+
+.. autoclass:: PortRangeType
+    :members:
+    :undoc-members:
+
+.. autoclass:: SeverityLevel
+    :members:
+    :undoc-members:
+
+.. autoclass:: SnmpAuthAlgorithm
+    :members:
+    :undoc-members:
+
+.. autoclass:: SnmpPrivacyAlgorithm
+    :members:
+    :undoc-members:
+
+.. autoclass:: TicketStatus
+    :members:
+    :undoc-members:
+
+Protocol
+--------
+
+.. autoclass:: Gmp
+    :members:
+    :inherited-members:

--- a/docs/api/protocols.rst
+++ b/docs/api/protocols.rst
@@ -12,6 +12,7 @@ Protocols
     gmpv8
     gmpv9
     gmpv208
+    gmpv214
     ospv1
 
 Dynamic
@@ -20,7 +21,13 @@ Dynamic
 To dynamically use the supported GMP version of the manager daemon see
 :mod:`gvm.protocols.gmp` for details.
 
-Latest
-^^^^^^
+"latest" protocols
+^^^^^^^^^^^^^^^^^^
 
 .. automodule:: gvm.protocols.latest
+
+
+"next" protocols
+^^^^^^^^^^^^^^^^
+
+.. automodule:: gvm.protocols.next

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,4 @@
-# -*- coding: utf-8 -*-
+﻿# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #
@@ -24,7 +24,7 @@ import gvm
 # -- Project information -----------------------------------------------------
 
 project = 'python-gvm'
-copyright = '2018 - 2019, Greenbone Networks GmbH'
+copyright = '2018 - 2021, Greenbone Networks GmbH'
 author = 'Greenbone Networks GmbH'
 
 # The short X.Y version

--- a/gvm/protocols/__init__.py
+++ b/gvm/protocols/__init__.py
@@ -19,7 +19,7 @@
 Package for supported Greenbone Protocol versions.
 
 Currently `GMP version 7`_, `GMP version 8`_, `GMP version 9`_ ,
-`GMP version 20.08`_ and `OSP version 1`_ are supported.
+`GMP version 20.08`_, `GMP version 21.04`_ and `OSP version 1`_ are supported.
 
 .. _GMP version 7:
     https://docs.greenbone.net/API/GMP/gmp-7.0.html
@@ -29,6 +29,8 @@ Currently `GMP version 7`_, `GMP version 8`_, `GMP version 9`_ ,
     https://docs.greenbone.net/API/GMP/gmp-9.0.html
 .. _GMP version 20.08:
     https://docs.greenbone.net/API/GMP/gmp-20.08.html
+.. _GMP version 21.04:
+    https://docs.greenbone.net/API/GMP/gmp-21.04.html
 .. _OSP version 1:
     https://docs.greenbone.net/API/OSP/osp-1.2.html
 """

--- a/gvm/protocols/next.py
+++ b/gvm/protocols/next.py
@@ -15,10 +15,10 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""Latest supported stable protocols.
+"""Latest supported protocols, including unstable ones.
 
-This module exposes the latest supported protocols for the newest stable
-release branch of GVM.
+This module exposes the latest supported protocols of GVM including versions
+not yet released as stable.
 
 The provided Gmp class implements the latest `Greenbone Management
 Protocol`_.
@@ -28,14 +28,14 @@ For details about the possible supported protocol versions please take a look at
 :py:mod:`gvm.protocols`.
 
 Exports:
-  - :py:class:`gvm.protocols.gmpv208.Gmp`
+  - :py:class:`gvm.protocols.gmpv214.Gmp`
   - :py:class:`gvm.protocols.ospv1.Osp`
 
 .. _Greenbone Management Protocol:
     https://docs.greenbone.net/API/GMP/gmp.html
 """
 
-from .gmpv208 import (
+from .gmpv214 import (
     Gmp,
     AggregateStatistic,
     AlertCondition,
@@ -52,7 +52,6 @@ from .gmpv208 import (
     InfoType,
     PermissionSubjectType,
     PortRangeType,
-    ReportFormatType,
     ScannerType,
     SeverityLevel,
     SnmpAuthAlgorithm,
@@ -76,7 +75,6 @@ from .gmpv208 import (
     get_info_type_from_string,
     get_permission_subject_type_from_string,
     get_port_range_type_from_string,
-    get_report_format_id_from_string,
     get_scanner_type_from_string,
     get_severity_level_from_string,
     get_snmp_auth_algorithm_from_string,
@@ -106,7 +104,6 @@ __all__ = [
     "InfoType",
     "PermissionSubjectType",
     "PortRangeType",
-    "ReportFormatType",
     "ScannerType",
     "SeverityLevel",
     "SnmpAuthAlgorithm",
@@ -130,7 +127,6 @@ __all__ = [
     "get_info_type_from_string",
     "get_permission_subject_type_from_string",
     "get_port_range_type_from_string",
-    "get_report_format_id_from_string",
     "get_scanner_type_from_string",
     "get_severity_level_from_string",
     "get_snmp_auth_algorithm_from_string",

--- a/tests/protocols/test_next.py
+++ b/tests/protocols/test_next.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.protocols.next import Gmp, Osp
+
+
+class LatestProtocolsTestCase(unittest.TestCase):
+    def test_gmp_version(self):
+        self.assertEqual(Gmp.get_protocol_version(), (21, 4))
+
+    def test_osp_version(self):
+        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
**What**:
This adds a new dynamic protocol version "next" which uses the newest
versions of GMP and OSP including unreleased / unstable ones.
Additionally GMP 21.04 has been added to the documentation.

**Why**:
To make the unreleased / unstable GMP version more usable with python-gvm.

**How**:
Tested by building the documentation.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [x] Documentation
