### PR TITLE
Removed superfluous GMP v9 link.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Calendar Versioning](https://calver.org)html).
   [#437](https://github.com/greenbone/python-gvm/pull/437)
   [#438](https://github.com/greenbone/python-gvm/pull/438)
   [#439](https://github.com/greenbone/python-gvm/pull/439)
+  [#444](https://github.com/greenbone/python-gvm/pull/444)
 
 ### Fixed
 

--- a/gvm/protocols/__init__.py
+++ b/gvm/protocols/__init__.py
@@ -21,7 +21,6 @@ Package for supported Greenbone Protocol versions.
 Currently `GMP version 20.08`_, `GMP version 21.04`_
 and `OSP version 1`_ are supported.
 
-    https://docs.greenbone.net/API/GMP/gmp-9.0.html
 .. _GMP version 20.08:
     https://docs.greenbone.net/API/GMP/gmp-20.08.html
 .. _GMP version 21.04:


### PR DESCRIPTION
A leftover from #439