### PR TITLE
[Refactor python-gvm API] Step 2: Detach Audits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Calendar Versioning](https://calver.org)html).
 * Introduced new explicit API calls for SecInfo: `get_nvt()`, `get_nvt_list()`, `get_cpe()`, `get_cpe_list()`, `get_cve()`, `get_cve_list()`, `get_cert_bund_advisory()`, `get_cert_bund_advisory_list()`, `get_dnf_cert_advisory()`, `get_dnf_cert_advisory_list()`, `get_oval_definition()`, `get_oval_definition_list()`. [#456](https://github.com/greenbone/python-gvm/pull/456)
 
 ### Changed
+* Detached the Audit API calls from the GMP class into a new `AuditsMixin`. [#464](https://github.com/greenbone/python-gvm/pull/464)
 * Changed the API calls `get_nvt()` and `get_nvts()` to `get_scan_config_nvt()` and `get_scan_config_nvts()`.  [#456](https://github.com/greenbone/python-gvm/pull/456)
 * Detached the `InfoType` from the GMP types class.  [#456](https://github.com/greenbone/python-gvm/pull/456)
 * Detached the SecInfo (CPE, CVE, NVT, CERT-BUND, DNF-CERT, OVAL Definitions) calls from GMP class into new `SecInfoMixin`. [#456](https://github.com/greenbone/python-gvm/pull/456)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Calendar Versioning](https://calver.org)html).
 * Detached the `PortListType` from the GMP types class. [#446](https://github.com/greenbone/python-gvm/pull/446)
 * Detached the ReportFormatType from the GMP types class. [#445](https://github.com/greenbone/python-gvm/pull/445)
 * Detached the Report API calls from the GMP class into a new `ReportMixin`. [#445](https://github.com/greenbone/python-gvm/pull/445)
-* Detached the Task API calls from the GMP class into a new `TaskMixin`. [#443](https://github.com/greenbone/python-gvm/pull/443)
+* Detached the Task API calls from the GMP class into a new `TasksMixin`. [#443](https://github.com/greenbone/python-gvm/pull/443)
 * Moved helper functions from gmp to utils. The response XML will not be recovered by the parser anymore! [#442](https://github.com/greenbone/python-gvm/pull/442)
 
 ### Deprecated

--- a/gvm/protocols/gmpv208/__init__.py
+++ b/gvm/protocols/gmpv208/__init__.py
@@ -70,7 +70,7 @@ from gvm.protocols.gmpv208.entities.targets import (
     get_alive_test_from_string,
     TargetsMixin,
 )
-from gvm.protocols.gmpv208.entities.tasks import TaskMixin
+from gvm.protocols.gmpv208.entities.tasks import TasksMixin
 from gvm.protocols.gmpv208.entities.tls_certificates import TLSCertificateMixin
 from gvm.connections import GvmConnection
 
@@ -92,7 +92,7 @@ class Gmp(
     ReportsMixin,
     ResultsMixin,
     TargetsMixin,
-    TaskMixin,
+    TasksMixin,
     TLSCertificateMixin,
     SecInfoMixin,
 ):

--- a/gvm/protocols/gmpv208/__init__.py
+++ b/gvm/protocols/gmpv208/__init__.py
@@ -37,6 +37,7 @@ from gvm.protocols.gmpv208.entities.alerts import (
     get_alert_event_from_string,
     get_alert_method_from_string,
 )
+from gvm.protocols.gmpv208.entities.audits import AuditsMixin
 from gvm.protocols.gmpv208.entities.hosts import (
     HostsMixin,
 )
@@ -84,6 +85,7 @@ PROTOCOL_VERSION = (20, 8)
 class Gmp(
     GmpV208Mixin,
     AlertsMixin,
+    AuditsMixin,
     HostsMixin,
     NotesMixin,
     OperatingSystemsMixin,

--- a/gvm/protocols/gmpv208/entities/audits.py
+++ b/gvm/protocols/gmpv208/entities/audits.py
@@ -1,0 +1,448 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint:  disable=redefined-builtin
+
+from collections.abc import Mapping
+from numbers import Integral
+from typing import Any, List, Optional
+
+from gvm.errors import InvalidArgument, InvalidArgumentType, RequiredArgument
+from gvm.protocols.gmpv208.types import (
+    HostsOrdering,
+)  # if I use latest, I get circular import :/
+from gvm.utils import add_filter, is_list_like, to_bool, to_comma_list
+from gvm.xml import XmlCommand
+
+
+class AuditsMixin:
+    def clone_audit(self, audit_id: str) -> Any:
+        """Clone an existing audit
+
+        Arguments:
+            audit_id: UUID of existing audit to clone from
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not audit_id:
+            raise RequiredArgument(
+                function=self.clone_audit.__name__, argument='audit_id'
+            )
+
+        cmd = XmlCommand("create_task")
+        cmd.add_element("copy", audit_id)
+        return self._send_xml_command(cmd)
+
+    def create_audit(
+        self,
+        name: str,
+        policy_id: str,
+        target_id: str,
+        scanner_id: str,
+        *,
+        alterable: Optional[bool] = None,
+        hosts_ordering: Optional[HostsOrdering] = None,
+        schedule_id: Optional[str] = None,
+        alert_ids: Optional[List[str]] = None,
+        comment: Optional[str] = None,
+        schedule_periods: Optional[int] = None,
+        observers: Optional[List[str]] = None,
+        preferences: Optional[dict] = None,
+    ) -> Any:
+        """Create a new audit task
+
+        Arguments:
+            name: Name of the new audit
+            policy_id: UUID of policy to use by the audit
+            target_id: UUID of target to be scanned
+            scanner_id: UUID of scanner to use for scanning the target
+            comment: Comment for the audit
+            alterable: Whether the task should be alterable
+            alert_ids: List of UUIDs for alerts to be applied to the audit
+            hosts_ordering: The order hosts are scanned in
+            schedule_id: UUID of a schedule when the audit should be run.
+            schedule_periods: A limit to the number of times the audit will be
+                scheduled, or 0 for no limit
+            observers: List of names or ids of users which should be allowed to
+                observe this audit
+            preferences: Name/Value pairs of scanner preferences.
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+
+        if not name:
+            raise RequiredArgument(
+                function=self.create_audit.__name__, argument='name'
+            )
+        if not policy_id:
+            raise RequiredArgument(
+                function=self.create_audit.__name__, argument='policy_id'
+            )
+
+        if not target_id:
+            raise RequiredArgument(
+                function=self.create_audit.__name__, argument='target_id'
+            )
+
+        if not scanner_id:
+            raise RequiredArgument(
+                function=self.create_audit.__name__, argument='scanner_id'
+            )
+
+        # don't allow to create a container task with create_task
+        if target_id == '0':
+            raise InvalidArgument(
+                function=self.create_audit.__name__, argument='target_id'
+            )
+
+        cmd = XmlCommand("create_task")
+        cmd.add_element("name", name)
+        cmd.add_element("usage_type", "audit")
+        cmd.add_element("config", attrs={"id": policy_id})
+        cmd.add_element("target", attrs={"id": target_id})
+        cmd.add_element("scanner", attrs={"id": scanner_id})
+
+        if comment:
+            cmd.add_element("comment", comment)
+
+        if alterable is not None:
+            cmd.add_element("alterable", to_bool(alterable))
+
+        if hosts_ordering:
+            if not isinstance(hosts_ordering, self.types.HostsOrdering):
+                raise InvalidArgumentType(
+                    function=self.create_audit.__name__,
+                    argument='hosts_ordering',
+                    arg_type=HostsOrdering.__name__,
+                )
+            cmd.add_element("hosts_ordering", hosts_ordering.value)
+
+        if alert_ids:
+            if is_list_like(alert_ids):
+                # parse all given alert id's
+                for alert in alert_ids:
+                    cmd.add_element("alert", attrs={"id": str(alert)})
+
+        if schedule_id:
+            cmd.add_element("schedule", attrs={"id": schedule_id})
+
+            if schedule_periods is not None:
+                if (
+                    not isinstance(schedule_periods, Integral)
+                    or schedule_periods < 0
+                ):
+                    raise InvalidArgument(
+                        "schedule_periods must be an integer greater or equal "
+                        "than 0"
+                    )
+                cmd.add_element("schedule_periods", str(schedule_periods))
+
+        if observers is not None:
+            if not is_list_like(observers):
+                raise InvalidArgumentType(
+                    function=self.create_audit.__name__,
+                    argument='observers',
+                    arg_type='list',
+                )
+
+            # gvmd splits by comma and space
+            # gvmd tries to lookup each value as user name and afterwards as
+            # user id. So both user name and user id are possible
+            cmd.add_element("observers", to_comma_list(observers))
+
+        if preferences is not None:
+            if not isinstance(preferences, Mapping):
+                raise InvalidArgumentType(
+                    function=self.create_audit.__name__,
+                    argument='preferences',
+                    arg_type=Mapping.__name__,
+                )
+
+            _xmlprefs = cmd.add_element("preferences")
+            for pref_name, pref_value in preferences.items():
+                _xmlpref = _xmlprefs.add_element("preference")
+                _xmlpref.add_element("scanner_name", pref_name)
+                _xmlpref.add_element("value", str(pref_value))
+
+        return self._send_xml_command(cmd)
+
+    def delete_audit(
+        self, audit_id: str, *, ultimate: Optional[bool] = False
+    ) -> Any:
+        """Deletes an existing audit
+
+        Arguments:
+            audit_id: UUID of the audit to be deleted.
+            ultimate: Whether to remove entirely, or to the trashcan.
+        """
+        if not audit_id:
+            raise RequiredArgument(
+                function=self.delete_audit.__name__, argument='audit_id'
+            )
+
+        cmd = XmlCommand("delete_task")
+        cmd.set_attribute("task_id", audit_id)
+        cmd.set_attribute("ultimate", to_bool(ultimate))
+
+        return self._send_xml_command(cmd)
+
+    def get_audits(
+        self,
+        *,
+        filter: Optional[str] = None,
+        filter_id: Optional[str] = None,
+        trash: Optional[bool] = None,
+        details: Optional[bool] = None,
+        schedules_only: Optional[bool] = None,
+    ) -> Any:
+        """Request a list of audits
+
+        Arguments:
+            filter: Filter term to use for the query
+            filter_id: UUID of an existing filter to use for the query
+            trash: Whether to get the trashcan audits instead
+            details: Whether to include full audit details
+            schedules_only: Whether to only include id, name and schedule
+                details
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        cmd = XmlCommand("get_tasks")
+        cmd.set_attribute("usage_type", "audit")
+
+        add_filter(cmd, filter, filter_id)
+
+        if trash is not None:
+            cmd.set_attribute("trash", to_bool(trash))
+
+        if details is not None:
+            cmd.set_attribute("details", to_bool(details))
+
+        if schedules_only is not None:
+            cmd.set_attribute("schedules_only", to_bool(schedules_only))
+
+        return self._send_xml_command(cmd)
+
+    def get_audit(self, audit_id: str) -> Any:
+        """Request a single audit
+
+        Arguments:
+            audit_id: UUID of an existing audit
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not audit_id:
+            raise RequiredArgument(
+                function=self.get_task.__name__, argument='audit_id'
+            )
+
+        cmd = XmlCommand("get_tasks")
+        cmd.set_attribute("task_id", audit_id)
+        cmd.set_attribute("usage_type", "audit")
+
+        # for single entity always request all details
+        cmd.set_attribute("details", "1")
+        return self._send_xml_command(cmd)
+
+    def modify_audit(
+        self,
+        audit_id: str,
+        *,
+        name: Optional[str] = None,
+        policy_id: Optional[str] = None,
+        target_id: Optional[str] = None,
+        scanner_id: Optional[str] = None,
+        alterable: Optional[bool] = None,
+        hosts_ordering: Optional[HostsOrdering] = None,
+        schedule_id: Optional[str] = None,
+        schedule_periods: Optional[int] = None,
+        comment: Optional[str] = None,
+        alert_ids: Optional[List[str]] = None,
+        observers: Optional[List[str]] = None,
+        preferences: Optional[dict] = None,
+    ) -> Any:
+        """Modifies an existing task.
+
+        Arguments:
+            audit_id: UUID of audit to modify.
+            name: The name of the audit.
+            policy_id: UUID of policy to use by the audit
+            target_id: UUID of target to be scanned
+            scanner_id: UUID of scanner to use for scanning the target
+            comment: The comment on the audit.
+            alert_ids: List of UUIDs for alerts to be applied to the audit
+            hosts_ordering: The order hosts are scanned in
+            schedule_id: UUID of a schedule when the audit should be run.
+            schedule_periods: A limit to the number of times the audit will be
+                scheduled, or 0 for no limit.
+            observers: List of names or ids of users which should be allowed to
+                observe this audit
+            preferences: Name/Value pairs of scanner preferences.
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not audit_id:
+            raise RequiredArgument(
+                function=self.modify_task.__name__, argument='task_id argument'
+            )
+
+        cmd = XmlCommand("modify_task")
+        cmd.set_attribute("task_id", audit_id)
+
+        if name:
+            cmd.add_element("name", name)
+
+        if comment:
+            cmd.add_element("comment", comment)
+
+        if policy_id:
+            cmd.add_element("config", attrs={"id": policy_id})
+
+        if target_id:
+            cmd.add_element("target", attrs={"id": target_id})
+
+        if alterable is not None:
+            cmd.add_element("alterable", to_bool(alterable))
+
+        if hosts_ordering:
+            if not isinstance(hosts_ordering, HostsOrdering):
+                raise InvalidArgumentType(
+                    function=self.modify_task.__name__,
+                    argument='hosts_ordering',
+                    arg_type=HostsOrdering.__name__,
+                )
+            cmd.add_element("hosts_ordering", hosts_ordering.value)
+
+        if scanner_id:
+            cmd.add_element("scanner", attrs={"id": scanner_id})
+
+        if schedule_id:
+            cmd.add_element("schedule", attrs={"id": schedule_id})
+
+        if schedule_periods is not None:
+            if (
+                not isinstance(schedule_periods, Integral)
+                or schedule_periods < 0
+            ):
+                raise InvalidArgument(
+                    "schedule_periods must be an integer greater or equal "
+                    "than 0"
+                )
+            cmd.add_element("schedule_periods", str(schedule_periods))
+
+        if alert_ids is not None:
+            if not is_list_like(alert_ids):
+                raise InvalidArgumentType(
+                    function=self.modify_task.__name__,
+                    argument='alert_ids',
+                    arg_type='list',
+                )
+
+            if len(alert_ids) == 0:
+                cmd.add_element("alert", attrs={"id": "0"})
+            else:
+                for alert in alert_ids:
+                    cmd.add_element("alert", attrs={"id": str(alert)})
+
+        if observers is not None:
+            if not is_list_like(observers):
+                raise InvalidArgumentType(
+                    function=self.modify_task.__name__,
+                    argument='observers',
+                    arg_type='list',
+                )
+
+            cmd.add_element("observers", to_comma_list(observers))
+
+        if preferences is not None:
+            if not isinstance(preferences, Mapping):
+                raise InvalidArgumentType(
+                    function=self.modify_task.__name__,
+                    argument='preferences',
+                    arg_type=Mapping.__name__,
+                )
+
+            _xmlprefs = cmd.add_element("preferences")
+            for pref_name, pref_value in preferences.items():
+                _xmlpref = _xmlprefs.add_element("preference")
+                _xmlpref.add_element("scanner_name", pref_name)
+                _xmlpref.add_element("value", str(pref_value))
+
+        return self._send_xml_command(cmd)
+
+    def resume_audit(self, audit_id: str) -> Any:
+        """Resume an existing stopped audit
+
+        Arguments:
+            audit_id: UUID of the audit to be resumed
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not audit_id:
+            raise RequiredArgument(
+                function=self.resume_audit.__name__, argument='audit_id'
+            )
+
+        cmd = XmlCommand("resume_task")
+        cmd.set_attribute("task_id", audit_id)
+
+        return self._send_xml_command(cmd)
+
+    def start_audit(self, audit_id: str) -> Any:
+        """Start an existing audit
+
+        Arguments:
+            audit_id: UUID of the audit to be started
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not audit_id:
+            raise RequiredArgument(
+                function=self.start_audit.__name__, argument='audit_id'
+            )
+
+        cmd = XmlCommand("start_task")
+        cmd.set_attribute("task_id", audit_id)
+
+        return self._send_xml_command(cmd)
+
+    def stop_audit(self, audit_id: str) -> Any:
+        """Stop an existing running audit
+
+        Arguments:
+            audit_id: UUID of the audit to be stopped
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not audit_id:
+            raise RequiredArgument(
+                function=self.stop_audit.__name__, argument='audit_id'
+            )
+
+        cmd = XmlCommand("stop_task")
+        cmd.set_attribute("task_id", audit_id)
+
+        return self._send_xml_command(cmd)

--- a/gvm/protocols/gmpv208/entities/tasks.py
+++ b/gvm/protocols/gmpv208/entities/tasks.py
@@ -28,7 +28,7 @@ from gvm.utils import is_list_like, to_bool, to_comma_list
 from gvm.xml import XmlCommand
 
 
-class TaskMixin:
+class TasksMixin:
     def clone_task(self, task_id: str) -> Any:
         """Clone an existing task
 

--- a/gvm/protocols/gmpv208/gmpv208.py
+++ b/gvm/protocols/gmpv208/gmpv208.py
@@ -1059,37 +1059,6 @@ class GmpV208Mixin(GvmProtocol):
         """
         return self.__get_config(policy_id, UsageType.POLICY, tasks=audits)
 
-    def get_tasks(
-        self,
-        *,
-        filter: Optional[str] = None,
-        filter_id: Optional[str] = None,
-        trash: Optional[bool] = None,
-        details: Optional[bool] = None,
-        schedules_only: Optional[bool] = None,
-    ) -> Any:
-        """Request a list of tasks
-
-        Arguments:
-            filter: Filter term to use for the query
-            filter_id: UUID of an existing filter to use for the query
-            trash: Whether to get the trashcan tasks instead
-            details: Whether to include full task details
-            schedules_only: Whether to only include id, name and schedule
-                details
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-        return self.__get_tasks(
-            UsageType.SCAN,
-            filter=filter,
-            filter_id=filter_id,
-            trash=trash,
-            details=details,
-            schedules_only=schedules_only,
-        )
-
     def get_audits(
         self,
         *,
@@ -1120,17 +1089,6 @@ class GmpV208Mixin(GvmProtocol):
             details=details,
             schedules_only=schedules_only,
         )
-
-    def get_task(self, task_id: str) -> Any:
-        """Request a single task
-
-        Arguments:
-            task_id: UUID of an existing task
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-        return self.__get_task(task_id, UsageType.SCAN)
 
     def get_audit(self, audit_id: str) -> Any:
         """Request a single audit

--- a/gvm/protocols/gmpv208/gmpv208.py
+++ b/gvm/protocols/gmpv208/gmpv208.py
@@ -25,7 +25,6 @@ Module for communication with gvmd in
 .. _Greenbone Management Protocol version 20.08:
     https://docs.greenbone.net/API/GMP/gmp-20.08.html
 """
-import collections
 import logging
 from numbers import Integral
 
@@ -143,61 +142,6 @@ class GmpV208Mixin(GvmProtocol):
             self._authenticated = True
 
         return self._transform(response)
-
-    def create_audit(
-        self,
-        name: str,
-        policy_id: str,
-        target_id: str,
-        scanner_id: str,
-        *,
-        alterable: Optional[bool] = None,
-        hosts_ordering: Optional[HostsOrdering] = None,
-        schedule_id: Optional[str] = None,
-        alert_ids: Optional[List[str]] = None,
-        comment: Optional[str] = None,
-        schedule_periods: Optional[int] = None,
-        observers: Optional[List[str]] = None,
-        preferences: Optional[dict] = None,
-    ) -> Any:
-        """Create a new audit task
-
-        Arguments:
-            name: Name of the new audit
-            policy_id: UUID of policy to use by the audit
-            target_id: UUID of target to be scanned
-            scanner_id: UUID of scanner to use for scanning the target
-            comment: Comment for the audit
-            alterable: Whether the task should be alterable
-            alert_ids: List of UUIDs for alerts to be applied to the audit
-            hosts_ordering: The order hosts are scanned in
-            schedule_id: UUID of a schedule when the audit should be run.
-            schedule_periods: A limit to the number of times the audit will be
-                scheduled, or 0 for no limit
-            observers: List of names or ids of users which should be allowed to
-                observe this audit
-            preferences: Name/Value pairs of scanner preferences.
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-
-        return self.__create_task(
-            name=name,
-            config_id=policy_id,
-            target_id=target_id,
-            scanner_id=scanner_id,
-            usage_type=UsageType.AUDIT,
-            function=self.create_audit.__name__,
-            alterable=alterable,
-            hosts_ordering=hosts_ordering,
-            schedule_id=schedule_id,
-            alert_ids=alert_ids,
-            comment=comment,
-            schedule_periods=schedule_periods,
-            observers=observers,
-            preferences=preferences,
-        )
 
     def create_config(
         self, config_id: str, name: str, *, comment: Optional[str] = None
@@ -600,60 +544,6 @@ class GmpV208Mixin(GvmProtocol):
         cmd.set_attributes(kwargs)
 
         return self._send_xml_command(cmd)
-
-    def modify_audit(
-        self,
-        audit_id: str,
-        *,
-        name: Optional[str] = None,
-        policy_id: Optional[str] = None,
-        target_id: Optional[str] = None,
-        scanner_id: Optional[str] = None,
-        alterable: Optional[bool] = None,
-        hosts_ordering: Optional[HostsOrdering] = None,
-        schedule_id: Optional[str] = None,
-        schedule_periods: Optional[int] = None,
-        comment: Optional[str] = None,
-        alert_ids: Optional[List[str]] = None,
-        observers: Optional[List[str]] = None,
-        preferences: Optional[dict] = None,
-    ) -> Any:
-        """Modifies an existing task.
-
-        Arguments:
-            audit_id: UUID of audit to modify.
-            name: The name of the audit.
-            policy_id: UUID of policy to use by the audit
-            target_id: UUID of target to be scanned
-            scanner_id: UUID of scanner to use for scanning the target
-            comment: The comment on the audit.
-            alert_ids: List of UUIDs for alerts to be applied to the audit
-            hosts_ordering: The order hosts are scanned in
-            schedule_id: UUID of a schedule when the audit should be run.
-            schedule_periods: A limit to the number of times the audit will be
-                scheduled, or 0 for no limit.
-            observers: List of names or ids of users which should be allowed to
-                observe this audit
-            preferences: Name/Value pairs of scanner preferences.
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-        self.modify_task(
-            task_id=audit_id,
-            name=name,
-            config_id=policy_id,
-            target_id=target_id,
-            scanner_id=scanner_id,
-            alterable=alterable,
-            hosts_ordering=hosts_ordering,
-            schedule_id=schedule_id,
-            schedule_periods=schedule_periods,
-            comment=comment,
-            alert_ids=alert_ids,
-            observers=observers,
-            preferences=preferences,
-        )
 
     def modify_permission(
         self,
@@ -1059,66 +949,6 @@ class GmpV208Mixin(GvmProtocol):
         """
         return self.__get_config(policy_id, UsageType.POLICY, tasks=audits)
 
-    def get_audits(
-        self,
-        *,
-        filter: Optional[str] = None,
-        filter_id: Optional[str] = None,
-        trash: Optional[bool] = None,
-        details: Optional[bool] = None,
-        schedules_only: Optional[bool] = None,
-    ) -> Any:
-        """Request a list of audits
-
-        Arguments:
-            filter: Filter term to use for the query
-            filter_id: UUID of an existing filter to use for the query
-            trash: Whether to get the trashcan audits instead
-            details: Whether to include full audit details
-            schedules_only: Whether to only include id, name and schedule
-                details
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-        return self.__get_tasks(
-            UsageType.AUDIT,
-            filter=filter,
-            filter_id=filter_id,
-            trash=trash,
-            details=details,
-            schedules_only=schedules_only,
-        )
-
-    def get_audit(self, audit_id: str) -> Any:
-        """Request a single audit
-
-        Arguments:
-            audit_id: UUID of an existing audit
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-        return self.__get_task(audit_id, UsageType.AUDIT)
-
-    def clone_audit(self, audit_id: str) -> Any:
-        """Clone an existing audit
-
-        Arguments:
-            audit_id: UUID of existing audit to clone from
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-        if not audit_id:
-            raise RequiredArgument(
-                function=self.clone_audit.__name__, argument='audit_id'
-            )
-
-        cmd = XmlCommand("create_task")
-        cmd.add_element("copy", audit_id)
-        return self._send_xml_command(cmd)
-
     def clone_policy(self, policy_id: str) -> Any:
         """Clone a policy from an existing one
 
@@ -1137,31 +967,10 @@ class GmpV208Mixin(GvmProtocol):
         cmd.add_element("copy", policy_id)
         return self._send_xml_command(cmd)
 
-    def delete_audit(
-        self, audit_id: str, *, ultimate: Optional[bool] = False
-    ) -> Any:
-        """Deletes an existing audit
-
-        Arguments:
-            audit_id: UUID of the audit to be deleted.
-            ultimate: Whether to remove entirely, or to the trashcan.
-        """
-        if not audit_id:
-            raise RequiredArgument(
-                function=self.delete_audit.__name__, argument='audit_id'
-            )
-
-        cmd = XmlCommand("delete_task")
-        cmd.set_attribute("task_id", audit_id)
-        cmd.set_attribute("ultimate", to_bool(ultimate))
-
-        return self._send_xml_command(cmd)
-
     def delete_policy(
         self, policy_id: str, *, ultimate: Optional[bool] = False
     ) -> Any:
         """Deletes an existing policy
-
         Arguments:
             policy_id: UUID of the policy to be deleted.
             ultimate: Whether to remove entirely, or to the trashcan.
@@ -1174,118 +983,6 @@ class GmpV208Mixin(GvmProtocol):
         cmd = XmlCommand("delete_config")
         cmd.set_attribute("config_id", policy_id)
         cmd.set_attribute("ultimate", to_bool(ultimate))
-
-        return self._send_xml_command(cmd)
-
-    def __create_task(
-        self,
-        name: str,
-        config_id: str,
-        target_id: str,
-        scanner_id: str,
-        usage_type: UsageType,
-        function: str,
-        *,
-        alterable: Optional[bool] = None,
-        hosts_ordering: Optional[HostsOrdering] = None,
-        schedule_id: Optional[str] = None,
-        alert_ids: Optional[List[str]] = None,
-        comment: Optional[str] = None,
-        schedule_periods: Optional[int] = None,
-        observers: Optional[List[str]] = None,
-        preferences: Optional[dict] = None,
-    ) -> Any:
-        if not name:
-            raise RequiredArgument(function=function, argument='name')
-
-        if not config_id:
-            raise RequiredArgument(function=function, argument='config_id')
-
-        if not target_id:
-            raise RequiredArgument(function=function, argument='target_id')
-
-        if not scanner_id:
-            raise RequiredArgument(function=function, argument='scanner_id')
-
-        # don't allow to create a container task with create_task
-        if target_id == '0':
-            raise InvalidArgument(function=function, argument='target_id')
-
-        cmd = XmlCommand("create_task")
-        cmd.add_element("name", name)
-        cmd.add_element("usage_type", usage_type.value)
-        cmd.add_element("config", attrs={"id": config_id})
-        cmd.add_element("target", attrs={"id": target_id})
-        cmd.add_element("scanner", attrs={"id": scanner_id})
-
-        if comment:
-            cmd.add_element("comment", comment)
-
-        if alterable is not None:
-            cmd.add_element("alterable", to_bool(alterable))
-
-        if hosts_ordering:
-            if not isinstance(hosts_ordering, self.types.HostsOrdering):
-                raise InvalidArgumentType(
-                    function=function,
-                    argument='hosts_ordering',
-                    arg_type=HostsOrdering.__name__,
-                )
-            cmd.add_element("hosts_ordering", hosts_ordering.value)
-
-        if alert_ids:
-            if isinstance(alert_ids, str):
-                deprecation(
-                    "Please pass a list as alert_ids parameter to {}. "
-                    "Passing a string is deprecated and will be removed in "
-                    "future.".format(function)
-                )
-
-                # if a single id is given as a string wrap it into a list
-                alert_ids = [alert_ids]
-            if is_list_like(alert_ids):
-                # parse all given alert id's
-                for alert in alert_ids:
-                    cmd.add_element("alert", attrs={"id": str(alert)})
-
-        if schedule_id:
-            cmd.add_element("schedule", attrs={"id": schedule_id})
-
-            if schedule_periods is not None:
-                if (
-                    not isinstance(schedule_periods, Integral)
-                    or schedule_periods < 0
-                ):
-                    raise InvalidArgument(
-                        "schedule_periods must be an integer greater or equal "
-                        "than 0"
-                    )
-                cmd.add_element("schedule_periods", str(schedule_periods))
-
-        if observers is not None:
-            if not is_list_like(observers):
-                raise InvalidArgumentType(
-                    function=function, argument='observers', arg_type='list'
-                )
-
-            # gvmd splits by comma and space
-            # gvmd tries to lookup each value as user name and afterwards as
-            # user id. So both user name and user id are possible
-            cmd.add_element("observers", to_comma_list(observers))
-
-        if preferences is not None:
-            if not isinstance(preferences, collections.abc.Mapping):
-                raise InvalidArgumentType(
-                    function=function,
-                    argument='preferences',
-                    arg_type=collections.abc.Mapping.__name__,
-                )
-
-            _xmlprefs = cmd.add_element("preferences")
-            for pref_name, pref_value in preferences.items():
-                _xmlpref = _xmlprefs.add_element("preference")
-                _xmlpref.add_element("scanner_name", pref_name)
-                _xmlpref.add_element("value", str(pref_value))
 
         return self._send_xml_command(cmd)
 
@@ -1391,103 +1088,6 @@ class GmpV208Mixin(GvmProtocol):
 
         # for single entity always request all details
         cmd.set_attribute("details", "1")
-
-        return self._send_xml_command(cmd)
-
-    def __get_tasks(
-        self,
-        usage_type: UsageType,
-        *,
-        filter: Optional[str] = None,
-        filter_id: Optional[str] = None,
-        trash: Optional[bool] = None,
-        details: Optional[bool] = None,
-        schedules_only: Optional[bool] = None,
-    ) -> Any:
-        cmd = XmlCommand("get_tasks")
-        cmd.set_attribute("usage_type", usage_type.value)
-
-        add_filter(cmd, filter, filter_id)
-
-        if trash is not None:
-            cmd.set_attribute("trash", to_bool(trash))
-
-        if details is not None:
-            cmd.set_attribute("details", to_bool(details))
-
-        if schedules_only is not None:
-            cmd.set_attribute("schedules_only", to_bool(schedules_only))
-
-        return self._send_xml_command(cmd)
-
-    def __get_task(self, task_id: str, usage_type: UsageType) -> Any:
-        if not task_id:
-            raise RequiredArgument(
-                function=self.get_task.__name__, argument='task_id'
-            )
-
-        cmd = XmlCommand("get_tasks")
-        cmd.set_attribute("task_id", task_id)
-        cmd.set_attribute("usage_type", usage_type.value)
-
-        # for single entity always request all details
-        cmd.set_attribute("details", "1")
-        return self._send_xml_command(cmd)
-
-    def resume_audit(self, audit_id: str) -> Any:
-        """Resume an existing stopped audit
-
-        Arguments:
-            audit_id: UUID of the audit to be resumed
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-        if not audit_id:
-            raise RequiredArgument(
-                function=self.resume_audit.__name__, argument='audit_id'
-            )
-
-        cmd = XmlCommand("resume_task")
-        cmd.set_attribute("task_id", audit_id)
-
-        return self._send_xml_command(cmd)
-
-    def start_audit(self, audit_id: str) -> Any:
-        """Start an existing audit
-
-        Arguments:
-            audit_id: UUID of the audit to be started
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-        if not audit_id:
-            raise RequiredArgument(
-                function=self.start_audit.__name__, argument='audit_id'
-            )
-
-        cmd = XmlCommand("start_task")
-        cmd.set_attribute("task_id", audit_id)
-
-        return self._send_xml_command(cmd)
-
-    def stop_audit(self, audit_id: str) -> Any:
-        """Stop an existing running audit
-
-        Arguments:
-            audit_id: UUID of the audit to be stopped
-
-        Returns:
-            The response. See :py:meth:`send_command` for details.
-        """
-        if not audit_id:
-            raise RequiredArgument(
-                function=self.stop_audit.__name__, argument='audit_id'
-            )
-
-        cmd = XmlCommand("stop_task")
-        cmd.set_attribute("task_id", audit_id)
 
         return self._send_xml_command(cmd)
 

--- a/gvm/protocols/gmpv214/__init__.py
+++ b/gvm/protocols/gmpv214/__init__.py
@@ -62,7 +62,7 @@ from gvm.protocols.gmpv208.entities.severity import (
     get_severity_level_from_string,
 )
 
-from gvm.protocols.gmpv208.entities.tasks import TaskMixin
+from gvm.protocols.gmpv208.entities.tasks import TasksMixin
 from gvm.protocols.gmpv208.entities.tls_certificates import TLSCertificateMixin
 from gvm.protocols.gmpv208.gmpv208 import GmpV208Mixin
 
@@ -96,7 +96,7 @@ class Gmp(
     ReportsMixin,
     ResultsMixin,
     TargetsMixin,
-    TaskMixin,
+    TasksMixin,
     TLSCertificateMixin,
     SecInfoMixin,
 ):

--- a/gvm/protocols/gmpv214/__init__.py
+++ b/gvm/protocols/gmpv214/__init__.py
@@ -37,6 +37,7 @@ from gvm.protocols.gmpv208.entities.alerts import (
     get_alert_event_from_string,
     get_alert_method_from_string,
 )
+from gvm.protocols.gmpv208.entities.audits import AuditsMixin
 from gvm.protocols.gmpv208.entities.hosts import HostsMixin
 from gvm.protocols.gmpv208.entities.operating_systems import (
     OperatingSystemsMixin,
@@ -88,6 +89,7 @@ class Gmp(
     GmpV214Mixin,
     GmpV208Mixin,
     AlertsMixin,
+    AuditsMixin,
     HostsMixin,
     PortListMixin,
     NotesMixin,

--- a/tests/protocols/gmpv208/entities/audits/__init__.py
+++ b/tests/protocols/gmpv208/entities/audits/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2021 Greenbone Networks GmbH
+# Copyright (C) 2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from gvm.errors import RequiredArgument
-
-
-class GmpCloneAuditTestCase:
-    def test_clone(self):
-        self.gmp.clone_audit('a1')
-
-        self.connection.send.has_been_called_with(
-            '<create_task><copy>a1</copy></create_task>'
-        )
-
-    def test_missing_id(self):
-        with self.assertRaises(RequiredArgument):
-            self.gmp.clone_audit('')
-
-        with self.assertRaises(RequiredArgument):
-            self.gmp.clone_audit(None)
+from .test_clone_audit import GmpCloneAuditTestMixin
+from .test_create_audit import GmpCreateAuditTestMixin
+from .test_delete_audit import GmpDeleteAuditTestMixin
+from .test_get_audit import GmpGetAuditTestMixin
+from .test_get_audits import GmpGetAuditsTestMixin
+from .test_modify_audit import GmpModifyAuditTestMixin
+from .test_resume_audit import GmpResumeAuditTestMixin
+from .test_start_audit import GmpStartAuditTestMixin
+from .test_stop_audit import GmpStopAuditTestMixin

--- a/tests/protocols/gmpv208/entities/audits/test_clone_audit.py
+++ b/tests/protocols/gmpv208/entities/audits/test_clone_audit.py
@@ -16,18 +16,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from gvm.errors import GvmError
+from gvm.errors import RequiredArgument
 
 
-class GmpStopAuditTestCase:
-    def test_stop_audit(self):
-        self.gmp.stop_audit('a1')
+class GmpCloneAuditTestMixin:
+    def test_clone(self):
+        self.gmp.clone_audit('a1')
 
-        self.connection.send.has_been_called_with('<stop_task task_id="a1"/>')
+        self.connection.send.has_been_called_with(
+            '<create_task><copy>a1</copy></create_task>'
+        )
 
     def test_missing_id(self):
-        with self.assertRaises(GvmError):
-            self.gmp.stop_audit(None)
+        with self.assertRaises(RequiredArgument):
+            self.gmp.clone_audit('')
 
-        with self.assertRaises(GvmError):
-            self.gmp.stop_audit('')
+        with self.assertRaises(RequiredArgument):
+            self.gmp.clone_audit(None)

--- a/tests/protocols/gmpv208/entities/audits/test_create_audit.py
+++ b/tests/protocols/gmpv208/entities/audits/test_create_audit.py
@@ -23,7 +23,7 @@ from gvm.errors import RequiredArgument, InvalidArgument, InvalidArgumentType
 from gvm.protocols.gmpv208 import HostsOrdering
 
 
-class GmpCreateAuditCommandTestCase:
+class GmpCreateAuditTestMixin:
     def test_create_task(self):
         self.gmp.create_audit(
             name='foo', policy_id='c1', target_id='t1', scanner_id='s1'

--- a/tests/protocols/gmpv208/entities/audits/test_delete_audit.py
+++ b/tests/protocols/gmpv208/entities/audits/test_delete_audit.py
@@ -19,15 +19,24 @@
 from gvm.errors import GvmError
 
 
-class GmpStartAuditTestCase:
-    def test_start_audit(self):
-        self.gmp.start_audit('a1')
+class GmpDeleteAuditTestMixin:
+    def test_delete(self):
+        self.gmp.delete_audit('a1')
 
-        self.connection.send.has_been_called_with('<start_task task_id="a1"/>')
+        self.connection.send.has_been_called_with(
+            '<delete_task task_id="a1" ultimate="0"/>'
+        )
+
+    def test_delete_ultimate(self):
+        self.gmp.delete_audit('a1', ultimate=True)
+
+        self.connection.send.has_been_called_with(
+            '<delete_task task_id="a1" ultimate="1"/>'
+        )
 
     def test_missing_id(self):
         with self.assertRaises(GvmError):
-            self.gmp.start_audit(None)
+            self.gmp.delete_audit(None)
 
         with self.assertRaises(GvmError):
-            self.gmp.start_audit('')
+            self.gmp.delete_audit('')

--- a/tests/protocols/gmpv208/entities/audits/test_get_audit.py
+++ b/tests/protocols/gmpv208/entities/audits/test_get_audit.py
@@ -19,7 +19,7 @@
 from gvm.errors import GvmError
 
 
-class GmpGetAuditTestCase:
+class GmpGetAuditTestMixin:
     def test_get_audit(self):
         self.gmp.get_audit('a1')
 

--- a/tests/protocols/gmpv208/entities/audits/test_get_audits.py
+++ b/tests/protocols/gmpv208/entities/audits/test_get_audits.py
@@ -17,7 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-class GmpGetAuditsTestCase:
+class GmpGetAuditsTestMixin:
     def test_get_audits_simple(self):
         self.gmp.get_audits()
 

--- a/tests/protocols/gmpv208/entities/audits/test_modify_audit.py
+++ b/tests/protocols/gmpv208/entities/audits/test_modify_audit.py
@@ -23,7 +23,7 @@ from gvm.errors import RequiredArgument, InvalidArgument, InvalidArgumentType
 from gvm.protocols.gmpv208 import HostsOrdering
 
 
-class GmpModifyAuditCommandTestCase:
+class GmpModifyAuditTestMixin:
     def test_modify_task(self):
         self.gmp.modify_audit('t1')
 

--- a/tests/protocols/gmpv208/entities/audits/test_resume_audit.py
+++ b/tests/protocols/gmpv208/entities/audits/test_resume_audit.py
@@ -19,24 +19,15 @@
 from gvm.errors import GvmError
 
 
-class GmpDeleteAuditTestCase:
-    def test_delete(self):
-        self.gmp.delete_audit('a1')
+class GmpResumeAuditTestMixin:
+    def test_resume_audit(self):
+        self.gmp.resume_audit('a1')
 
-        self.connection.send.has_been_called_with(
-            '<delete_task task_id="a1" ultimate="0"/>'
-        )
-
-    def test_delete_ultimate(self):
-        self.gmp.delete_audit('a1', ultimate=True)
-
-        self.connection.send.has_been_called_with(
-            '<delete_task task_id="a1" ultimate="1"/>'
-        )
+        self.connection.send.has_been_called_with('<resume_task task_id="a1"/>')
 
     def test_missing_id(self):
         with self.assertRaises(GvmError):
-            self.gmp.delete_audit(None)
+            self.gmp.resume_audit(None)
 
         with self.assertRaises(GvmError):
-            self.gmp.delete_audit('')
+            self.gmp.resume_audit('')

--- a/tests/protocols/gmpv208/entities/audits/test_start_audit.py
+++ b/tests/protocols/gmpv208/entities/audits/test_start_audit.py
@@ -19,15 +19,15 @@
 from gvm.errors import GvmError
 
 
-class GmpResumeAuditTestCase:
-    def test_resume_audit(self):
-        self.gmp.resume_audit('a1')
+class GmpStartAuditTestMixin:
+    def test_start_audit(self):
+        self.gmp.start_audit('a1')
 
-        self.connection.send.has_been_called_with('<resume_task task_id="a1"/>')
+        self.connection.send.has_been_called_with('<start_task task_id="a1"/>')
 
     def test_missing_id(self):
         with self.assertRaises(GvmError):
-            self.gmp.resume_audit(None)
+            self.gmp.start_audit(None)
 
         with self.assertRaises(GvmError):
-            self.gmp.resume_audit('')
+            self.gmp.start_audit('')

--- a/tests/protocols/gmpv208/entities/audits/test_stop_audit.py
+++ b/tests/protocols/gmpv208/entities/audits/test_stop_audit.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import GvmError
+
+
+class GmpStopAuditTestMixin:
+    def test_stop_audit(self):
+        self.gmp.stop_audit('a1')
+
+        self.connection.send.has_been_called_with('<stop_task task_id="a1"/>')
+
+    def test_missing_id(self):
+        with self.assertRaises(GvmError):
+            self.gmp.stop_audit(None)
+
+        with self.assertRaises(GvmError):
+            self.gmp.stop_audit('')

--- a/tests/protocols/gmpv208/entities/test_audits.py
+++ b/tests/protocols/gmpv208/entities/test_audits.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208 import Gmpv208TestCase
+from .audits import (
+    GmpCloneAuditTestMixin,
+    GmpCreateAuditTestMixin,
+    GmpDeleteAuditTestMixin,
+    GmpGetAuditsTestMixin,
+    GmpGetAuditTestMixin,
+    GmpModifyAuditTestMixin,
+    GmpResumeAuditTestMixin,
+    GmpStartAuditTestMixin,
+    GmpStopAuditTestMixin,
+)
+
+
+class Gmpv208CloneAuditTestCase(GmpCloneAuditTestMixin, Gmpv208TestCase):
+    pass
+
+
+class Gmpv208CreateAuditTestCase(GmpCreateAuditTestMixin, Gmpv208TestCase):
+    pass
+
+
+class Gmpv208DeleteAuditTestCase(GmpDeleteAuditTestMixin, Gmpv208TestCase):
+    pass
+
+
+class Gmpv208GetAuditTestCase(GmpGetAuditTestMixin, Gmpv208TestCase):
+    pass
+
+
+class Gmpv208GetAuditsTestCase(GmpGetAuditsTestMixin, Gmpv208TestCase):
+    pass
+
+
+class Gmpv208ModifyAuditTestCase(GmpModifyAuditTestMixin, Gmpv208TestCase):
+    pass
+
+
+class Gmpv208ResumeAuditTestCase(GmpResumeAuditTestMixin, Gmpv208TestCase):
+    pass
+
+
+class Gmpv208StartAuditTestCase(GmpStartAuditTestMixin, Gmpv208TestCase):
+    pass
+
+
+class Gmpv208StopAuditTestCase(GmpStopAuditTestMixin, Gmpv208TestCase):
+    pass

--- a/tests/protocols/gmpv208/test_new_gmpv208.py
+++ b/tests/protocols/gmpv208/test_new_gmpv208.py
@@ -62,22 +62,12 @@ class Gmpv208GetFeedTestCase(GmpGetFeedTestCase, Gmpv208TestCase):
     pass
 
 
-class Gmpv208CloneAuditTestCase(GmpCloneAuditTestCase, Gmpv208TestCase):
-    pass
-
-
 class Gmpv208CloneConfigTestCase(GmpCloneConfigTestCase, Gmpv208TestCase):
     pass
 
 
 class Gmpv208ClonePolicyTestCase(GmpClonePolicyTestCase, Gmpv208TestCase):
 
-    pass
-
-
-class Gmpv208CreateAuditCommandTestCase(
-    GmpCreateAuditCommandTestCase, Gmpv208TestCase
-):
     pass
 
 
@@ -101,24 +91,11 @@ class Gmpv208CreatePolicyTestCase(GmpCreatePolicyTestCase, Gmpv208TestCase):
     pass
 
 
-class Gmpv208DeleteAuditTestCase(GmpDeleteAuditTestCase, Gmpv208TestCase):
-    pass
-
-
 class Gmpv208DeleteConfigTestCase(GmpDeleteConfigTestCase, Gmpv208TestCase):
     pass
 
 
 class Gmpv208DeletePolicyTestCase(GmpDeletePolicyTestCase, Gmpv208TestCase):
-
-    pass
-
-
-class Gmpv208GetAuditTestCase(GmpGetAuditTestCase, Gmpv208TestCase):
-    pass
-
-
-class Gmpv208GetAuditsTestCase(GmpGetAuditsTestCase, Gmpv208TestCase):
 
     pass
 
@@ -136,12 +113,6 @@ class Gmpv208GetPoliciesTestCase(GmpGetPoliciesTestCase, Gmpv208TestCase):
 
 
 class Gmpv208GetPolicyTestCase(GmpGetPolicyTestCase, Gmpv208TestCase):
-    pass
-
-
-class Gmpv208ModifyAuditCommandTestCase(
-    GmpModifyAuditCommandTestCase, Gmpv208TestCase
-):
     pass
 
 
@@ -196,18 +167,6 @@ class Gmpv208CreateScannerTestCase(GmpCreateScannerTestCase, Gmpv208TestCase):
 
 
 class Gmpv208ModifyScannerTestCase(GmpModifyScannerTestCase, Gmpv208TestCase):
-    pass
-
-
-class Gmpv208ResumeAuditTestCase(GmpResumeAuditTestCase, Gmpv208TestCase):
-    pass
-
-
-class Gmpv208StartAuditTestCase(GmpStartAuditTestCase, Gmpv208TestCase):
-    pass
-
-
-class Gmpv208StopAuditTestCase(GmpStopAuditTestCase, Gmpv208TestCase):
     pass
 
 

--- a/tests/protocols/gmpv208/testcmds/__init__.py
+++ b/tests/protocols/gmpv208/testcmds/__init__.py
@@ -27,10 +27,8 @@ from .test_modify_permission import GmpModifyPermissionTestCase
 from .test_modify_report_format import GmpModifyReportFormatTestCase
 from .test_modify_tag import GmpModifyTagTestCase
 from .test_get_feed import GmpGetFeedTestCase
-from .test_clone_audit import GmpCloneAuditTestCase
 from .test_clone_config import GmpCloneConfigTestCase
 from .test_clone_policy import GmpClonePolicyTestCase
-from .test_create_audit import GmpCreateAuditCommandTestCase
 from .test_create_config import GmpCreateConfigTestCase
 from .test_create_config_from_osp_scanner import (
     GmpCreateConfigFromOSPScannerTestCase,
@@ -38,17 +36,13 @@ from .test_create_config_from_osp_scanner import (
 from .test_create_credential import GmpCreateCredentialTestCase
 from .test_create_policy import GmpCreatePolicyTestCase
 from .test_create_scanner import GmpCreateScannerTestCase
-from .test_delete_audit import GmpDeleteAuditTestCase
 from .test_delete_config import GmpDeleteConfigTestCase
 from .test_delete_policy import GmpDeletePolicyTestCase
-from .test_get_audit import GmpGetAuditTestCase
-from .test_get_audits import GmpGetAuditsTestCase
 from .test_get_config import GmpGetConfigTestCase
 from .test_get_configs import GmpGetConfigsTestCase
 from .test_get_policies import GmpGetPoliciesTestCase
 from .test_get_policy import GmpGetPolicyTestCase
 from .test_modify_credential import GmpModifyCredentialTestCase
-from .test_modify_audit import GmpModifyAuditCommandTestCase
 from .test_modify_policy_set_comment import GmpModifyPolicySetCommentTestCase
 from .test_modify_policy_set_family_selection import (
     GmpModifyPolicySetFamilySelectionTestCase,
@@ -65,9 +59,6 @@ from .test_modify_policy_set_scanner_preference import (
 )
 from .test_modify_scanner import GmpModifyScannerTestCase
 from .test_modify_ticket import GmpModifyTicketTestCase
-from .test_resume_audit import GmpResumeAuditTestCase
-from .test_start_audit import GmpStartAuditTestCase
-from .test_stop_audit import GmpStopAuditTestCase
 from .test_clone_ticket import GmpCloneTicketTestCase
 from .test_create_schedule import GmpCreateScheduleTestCase
 from .test_create_ticket import GmpCreateTicketTestCase

--- a/tests/protocols/gmpv208/testcmds/test_create_audit.py
+++ b/tests/protocols/gmpv208/testcmds/test_create_audit.py
@@ -15,7 +15,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import warnings
 
 from collections import OrderedDict
 
@@ -106,31 +105,6 @@ class GmpCreateAuditCommandTestCase:
 
     def test_create_audit_single_alert(self):
         # pylint: disable=invalid-name
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
-
-            self.gmp.create_audit(
-                name='foo',
-                policy_id='c1',
-                target_id='t1',
-                scanner_id='s1',
-                alert_ids='a1',  # will be removed in future
-            )
-
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
-
-        self.connection.send.has_been_called_with(
-            '<create_task>'
-            '<name>foo</name>'
-            '<usage_type>audit</usage_type>'
-            '<config id="c1"/>'
-            '<target id="t1"/>'
-            '<scanner id="s1"/>'
-            '<alert id="a1"/>'
-            '</create_task>'
-        )
-
         self.gmp.create_audit(
             name='foo',
             policy_id='c1',

--- a/tests/protocols/gmpv214/entities/test_audits.py
+++ b/tests/protocols/gmpv214/entities/test_audits.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv214 import Gmpv214TestCase
+from ...gmpv208.entities.audits import (
+    GmpCloneAuditTestMixin,
+    GmpCreateAuditTestMixin,
+    GmpDeleteAuditTestMixin,
+    GmpGetAuditsTestMixin,
+    GmpGetAuditTestMixin,
+    GmpModifyAuditTestMixin,
+    GmpResumeAuditTestMixin,
+    GmpStartAuditTestMixin,
+    GmpStopAuditTestMixin,
+)
+
+
+class Gmpv214CloneAuditTestCase(GmpCloneAuditTestMixin, Gmpv214TestCase):
+    pass
+
+
+class Gmpv214CreateAuditTestCase(GmpCreateAuditTestMixin, Gmpv214TestCase):
+    pass
+
+
+class Gmpv214DeleteAuditTestCase(GmpDeleteAuditTestMixin, Gmpv214TestCase):
+    pass
+
+
+class Gmpv214GetAuditTestCase(GmpGetAuditTestMixin, Gmpv214TestCase):
+    pass
+
+
+class Gmpv214GetAuditsTestCase(GmpGetAuditsTestMixin, Gmpv214TestCase):
+    pass
+
+
+class Gmpv214ModifyAuditTestCase(GmpModifyAuditTestMixin, Gmpv214TestCase):
+    pass
+
+
+class Gmpv214ResumeAuditTestCase(GmpResumeAuditTestMixin, Gmpv214TestCase):
+    pass
+
+
+class Gmpv214StartAuditTestCase(GmpStartAuditTestMixin, Gmpv214TestCase):
+    pass
+
+
+class Gmpv214StopAuditTestCase(GmpStopAuditTestMixin, Gmpv214TestCase):
+    pass

--- a/tests/protocols/gmpv214/test_v208_from_gmpv214.py
+++ b/tests/protocols/gmpv214/test_v208_from_gmpv214.py
@@ -62,22 +62,12 @@ class Gmpv214GetFeedTestCase(GmpGetFeedTestCase, Gmpv214TestCase):
     pass
 
 
-class Gmpv214CloneAuditTestCase(GmpCloneAuditTestCase, Gmpv214TestCase):
-    pass
-
-
 class Gmpv214CloneConfigTestCase(GmpCloneConfigTestCase, Gmpv214TestCase):
     pass
 
 
 class Gmpv214ClonePolicyTestCase(GmpClonePolicyTestCase, Gmpv214TestCase):
 
-    pass
-
-
-class Gmpv214CreateAuditCommandTestCase(
-    GmpCreateAuditCommandTestCase, Gmpv214TestCase
-):
     pass
 
 
@@ -101,24 +91,11 @@ class Gmpv214CreatePolicyTestCase(GmpCreatePolicyTestCase, Gmpv214TestCase):
     pass
 
 
-class Gmpv214DeleteAuditTestCase(GmpDeleteAuditTestCase, Gmpv214TestCase):
-    pass
-
-
 class Gmpv214DeleteConfigTestCase(GmpDeleteConfigTestCase, Gmpv214TestCase):
     pass
 
 
 class Gmpv214DeletePolicyTestCase(GmpDeletePolicyTestCase, Gmpv214TestCase):
-
-    pass
-
-
-class Gmpv214GetAuditTestCase(GmpGetAuditTestCase, Gmpv214TestCase):
-    pass
-
-
-class Gmpv214GetAuditsTestCase(GmpGetAuditsTestCase, Gmpv214TestCase):
 
     pass
 
@@ -136,12 +113,6 @@ class Gmpv214GetPoliciesTestCase(GmpGetPoliciesTestCase, Gmpv214TestCase):
 
 
 class Gmpv214GetPolicyTestCase(GmpGetPolicyTestCase, Gmpv214TestCase):
-    pass
-
-
-class Gmpv214ModifyAuditCommandTestCase(
-    GmpModifyAuditCommandTestCase, Gmpv214TestCase
-):
     pass
 
 
@@ -188,18 +159,6 @@ class Gmpv214ModifyPolicySetScannerPreferenceTestCase(
 
 
 class Gmpv214ModifyTicketTestCase(GmpModifyTicketTestCase, Gmpv214TestCase):
-    pass
-
-
-class Gmpv214ResumeAuditTestCase(GmpResumeAuditTestCase, Gmpv214TestCase):
-    pass
-
-
-class Gmpv214StartAuditTestCase(GmpStartAuditTestCase, Gmpv214TestCase):
-    pass
-
-
-class Gmpv214StopAuditTestCase(GmpStopAuditTestCase, Gmpv214TestCase):
     pass
 
 


### PR DESCRIPTION
**What**:

* Detach Audits into new AuditsMixin
* Remove deprecated support of str for alert_ids

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
