### PR TITLE
Missing create_task() documentation

### DIFF
--- a/gvm/protocols/gmpv208/entities/tasks.py
+++ b/gvm/protocols/gmpv208/entities/tasks.py
@@ -91,6 +91,27 @@ class TasksMixin:
         observers: Optional[List[str]] = None,
         preferences: Optional[dict] = None,
     ) -> Any:
+        """Create a new scan task
+
+        Arguments:
+            name: Name of the new task
+            config_id: UUID of config to use by the task
+            target_id: UUID of target to be scanned
+            scanner_id: UUID of scanner to use for scanning the target
+            comment: Comment for the task
+            alterable: Whether the task should be alterable
+            alert_ids: List of UUIDs for alerts to be applied to the task
+            hosts_ordering: The order hosts are scanned in
+            schedule_id: UUID of a schedule when the task should be run.
+            schedule_periods: A limit to the number of times the task will be
+                scheduled, or 0 for no limit
+            observers: List of names or ids of users which should be allowed to
+                observe this task
+            preferences: Name/Value pairs of scanner preferences.
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
         if not name:
             raise RequiredArgument(
                 function=self.create_task.__name__, argument='name'

--- a/tests/protocols/gmpv208/entities/audits/test_create_audit.py
+++ b/tests/protocols/gmpv208/entities/audits/test_create_audit.py
@@ -24,7 +24,7 @@ from gvm.protocols.gmpv208 import HostsOrdering
 
 
 class GmpCreateAuditTestMixin:
-    def test_create_task(self):
+    def test_create_audit(self):
         self.gmp.create_audit(
             name='foo', policy_id='c1', target_id='t1', scanner_id='s1'
         )


### PR DESCRIPTION
**What**:

Add missing `create_task()` documentation.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

https://github.com/greenbone/python-gvm/issues/487

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [x] Documentation
