### PR TITLE
Fix some typos in protocol gmpv208

### DIFF
--- a/gvm/protocols/gmpv208/entities/scan_configs.py
+++ b/gvm/protocols/gmpv208/entities/scan_configs.py
@@ -218,7 +218,7 @@ class ScanConfigsMixin:
         When the command includes a config_id attribute, the preference element
         includes the preference name, type and value, and the NVT to which the
         preference applies.
-        If the command includes a config_id and an nvt_oid, the preferencces for
+        If the command includes a config_id and an nvt_oid, the preferences for
         the given nvt in the config will be shown.
 
         Arguments:
@@ -549,7 +549,7 @@ class ScanConfigsMixin:
     ) -> Any:
         """Modifies an existing scan config.
 
-        DEPRECATED. Please use *modify_config_set_* methods instead.
+        DEPRECATED. Please use *modify_scan_config_set_* methods instead.
 
         modify_config has four modes to operate depending on the selection.
 

--- a/gvm/protocols/gmpv208/entities/schedules.py
+++ b/gvm/protocols/gmpv208/entities/schedules.py
@@ -216,7 +216,7 @@ class SchedulesMixin:
                 missing timezone information this timezone gets applied.
                 Otherwise the datetime values from the icalendar data are
                 displayed in this timezone
-            commenhedule.
+            comment: Comment on schedule.
 
         Returns:
             The response. See :py:meth:`send_command` for details.

--- a/gvm/protocols/gmpv208/system/user_settings.py
+++ b/gvm/protocols/gmpv208/system/user_settings.py
@@ -65,7 +65,7 @@ class UserSettingsMixin:
         name: Optional[str] = None,
         value: Optional[str] = None,
     ) -> Any:
-        """Modifies an existing usersetting.
+        """Modifies an existing user setting.
 
         Arguments:
             setting_id: UUID of the setting to be changed.


### PR DESCRIPTION
**What**:

Fix for some typos in protocol **gmpv208** documentation.

**Why**:

Not applicable.

**How**:

Not applicable.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
