### PR TITLE
Fixing dotted notation access to types in gmp.

### DIFF
--- a/gvm/protocols/gmpv208/__init__.py
+++ b/gvm/protocols/gmpv208/__init__.py
@@ -29,6 +29,7 @@ import logging
 from typing import Any, Callable, Optional
 
 from gvm.protocols.base import GvmProtocol
+from gvm.utils import to_dotted_types_dict
 
 from gvm.protocols.gmpv208.entities.alerts import (
     AlertCondition,
@@ -222,6 +223,8 @@ class Gmp(
         transform: Optional[Callable[[str], Any]] = None,
     ):
         super().__init__(connection, transform=transform)
+
+        self.types = to_dotted_types_dict(_TYPE_FIELDS)
 
         # Is authenticated on gvmd
         self._authenticated = False

--- a/gvm/protocols/gmpv208/__init__.py
+++ b/gvm/protocols/gmpv208/__init__.py
@@ -130,6 +130,32 @@ from gvm.connections import GvmConnection
 
 logger = logging.getLogger(__name__)
 
+_TYPE_FIELDS = [
+    AggregateStatistic,
+    AlertCondition,
+    AlertEvent,
+    AlertMethod,
+    AliveTest,
+    CredentialFormat,
+    CredentialType,
+    EntityType,
+    FeedType,
+    FilterType,
+    HostsOrdering,
+    InfoType,
+    HelpFormat,
+    PortRangeType,
+    PermissionSubjectType,
+    ReportFormatType,
+    ScannerType,
+    SeverityLevel,
+    SnmpAuthAlgorithm,
+    SnmpPrivacyAlgorithm,
+    SortOrder,
+    TicketStatus,
+    UserAuthType,
+]
+
 
 class Gmp(
     GvmProtocol,

--- a/gvm/protocols/gmpv2110/__init__.py
+++ b/gvm/protocols/gmpv2110/__init__.py
@@ -30,6 +30,7 @@ import logging
 from typing import Any, Callable, Optional
 
 from gvm.protocols.base import GvmProtocol
+from gvm.utils import to_dotted_types_dict
 
 from gvm.protocols.gmpv208.entities.alerts import (
     AlertCondition,
@@ -226,9 +227,7 @@ class Gmp(
         *,
         transform: Optional[Callable[[str], Any]] = None,
     ):
-        self.types = {}
-        for t in _TYPE_FIELDS:
-            self.types[t.__name__] = t
+        self.types = to_dotted_types_dict(_TYPE_FIELDS)
 
         super().__init__(connection, transform=transform)
 

--- a/gvm/protocols/gmpv214/__init__.py
+++ b/gvm/protocols/gmpv214/__init__.py
@@ -30,6 +30,7 @@ import logging
 from typing import Any, Callable, Optional
 
 from gvm.protocols.base import GvmProtocol
+from gvm.utils import to_dotted_types_dict
 
 from gvm.protocols.gmpv208.entities.alerts import (
     AlertCondition,
@@ -225,9 +226,7 @@ class Gmp(
         *,
         transform: Optional[Callable[[str], Any]] = None,
     ):
-        self.types = {}
-        for t in _TYPE_FIELDS:
-            self.types[t.__name__] = t
+        self.types = to_dotted_types_dict(_TYPE_FIELDS)
 
         super().__init__(connection, transform=transform)
 

--- a/gvm/utils.py
+++ b/gvm/utils.py
@@ -30,6 +30,14 @@ from gvm.xml import create_parser
 logger = logging.getLogger(__name__)
 
 
+class TypesDict(dict):
+    """For dot.notation access to dictionary attributes"""
+
+    __getattr__ = dict.get
+    __setattr__ = dict.__setitem__
+    __delattr__ = dict.__delitem__
+
+
 def deprecation(message: str):
     warnings.warn(message, DeprecationWarning, stacklevel=2)
 
@@ -60,6 +68,14 @@ def check_command_status(xml: str) -> bool:
     except etree.Error as e:
         logger.error("etree.XML(xml): %s", e)
         return False
+
+
+def to_dotted_types_dict(types: List) -> TypesDict:
+    """Create a dictionary accessible via dot notation"""
+    dic = {}
+    for typ in types:
+        dic[typ.__name__] = typ
+    return TypesDict(dic)
 
 
 def to_bool(value: bool) -> str:

--- a/tests/protocols/gmpv208/test_gmp_types.py
+++ b/tests/protocols/gmpv208/test_gmp_types.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.protocols.gmpv208.entities.hosts import HostsOrdering
+
+from . import Gmpv208TestCase
+
+
+class GmpWithStatementTestMixin:
+    def test_types(self):
+
+        with self.gmp:
+            # Test that the values are equal
+            self.assertEquals(
+                self.gmp.types.AlertEvent.TASK_RUN_STATUS_CHANGED.value,
+                'Task run status changed',
+            )
+            self.assertEquals(
+                self.gmp.types.PermissionSubjectType.USER.value, 'user'
+            )
+            self.assertEquals(
+                self.gmp.types.HostsOrdering.RANDOM.value, 'random'
+            )
+
+            # Test usability of from_string
+            self.assertEquals(
+                self.gmp.types.HostsOrdering.from_string('reverse'),
+                self.gmp.types.HostsOrdering.REVERSE,
+            )
+
+            # Test, that the Enum class types are equal
+            self.assertEquals(self.gmp.types.HostsOrdering, HostsOrdering)
+
+
+class Gmpv208WithStatementTestCase(GmpWithStatementTestMixin, Gmpv208TestCase):
+    pass

--- a/tests/protocols/gmpv2110/test_gmp_types.py
+++ b/tests/protocols/gmpv2110/test_gmp_types.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.protocols.gmpv208.entities.hosts import HostsOrdering
+
+from . import Gmpv2110TestCase
+
+
+class GmpWithStatementTestMixin:
+    def test_types(self):
+
+        with self.gmp:
+            # Test that the values are equal
+            self.assertEquals(
+                self.gmp.types.AlertEvent.TASK_RUN_STATUS_CHANGED.value,
+                'Task run status changed',
+            )
+            self.assertEquals(
+                self.gmp.types.PermissionSubjectType.USER.value, 'user'
+            )
+            self.assertEquals(
+                self.gmp.types.HostsOrdering.RANDOM.value, 'random'
+            )
+
+            # Test usability of from_string
+            self.assertEquals(
+                self.gmp.types.HostsOrdering.from_string('reverse'),
+                self.gmp.types.HostsOrdering.REVERSE,
+            )
+
+            # Test, that the Enum class types are equal
+            self.assertEquals(self.gmp.types.HostsOrdering, HostsOrdering)
+
+
+class Gmpv2110WithStatementTestCase(
+    GmpWithStatementTestMixin, Gmpv2110TestCase
+):
+    pass

--- a/tests/protocols/gmpv214/test_gmp_types.py
+++ b/tests/protocols/gmpv214/test_gmp_types.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.protocols.gmpv208.entities.hosts import HostsOrdering
+
+from . import Gmpv214TestCase
+
+
+class GmpWithStatementTestMixin:
+    def test_types(self):
+
+        with self.gmp:
+            # Test that the values are equal
+            self.assertEquals(
+                self.gmp.types.AlertEvent.TASK_RUN_STATUS_CHANGED.value,
+                'Task run status changed',
+            )
+            self.assertEquals(
+                self.gmp.types.PermissionSubjectType.USER.value, 'user'
+            )
+            self.assertEquals(
+                self.gmp.types.HostsOrdering.RANDOM.value, 'random'
+            )
+
+            # Test usability of from_string
+            self.assertEquals(
+                self.gmp.types.HostsOrdering.from_string('reverse'),
+                self.gmp.types.HostsOrdering.REVERSE,
+            )
+
+            # Test, that the Enum class types are equal
+            self.assertEquals(self.gmp.types.HostsOrdering, HostsOrdering)
+
+
+class Gmpv214WithStatementTestCase(GmpWithStatementTestMixin, Gmpv214TestCase):
+    pass


### PR DESCRIPTION
**What**:

Before:
```python
>>> gmp.types.HostsOrdering
Traceback (most recent call last):
  File "<console>", line 1, in <module>
AttributeError: 'dict' object has no attribute 'HostsOrdering'
```

After:
```python
>>> gmp.types.HostsOrdering
<enum 'HostsOrdering'>
>>> gmp.types.HostsOrdering.RANDOM
<HostsOrdering.RANDOM: 'random'>
```

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/main/CHANGELOG.md) Entry
- [ ] Documentation
