### PR TITLE
Ensure that connection is closed when using context manager

### DIFF
--- a/gvm/protocols/gmp.py
+++ b/gvm/protocols/gmp.py
@@ -19,7 +19,8 @@
 """
 Module for communication with gvmd
 """
-from typing import Any, Optional, Callable, Union
+from types import TracebackType
+from typing import Any, Optional, Callable, Union, Type
 
 from gvm.errors import GvmError
 
@@ -114,8 +115,17 @@ class Gmp(GvmProtocol):
         return gmp_class(self._connection, transform=self._gmp_transform)
 
     def __enter__(self):
-        gmp = self.determine_supported_gmp()
+        self._gmp = self.determine_supported_gmp()
 
-        gmp.connect()
+        self._gmp.connect()
 
-        return gmp
+        return self._gmp
+
+    def __exit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Any:
+        self._gmp.disconnect()
+        self._gmp = None

--- a/tests/protocols/gmp/test_context_manager.py
+++ b/tests/protocols/gmp/test_context_manager.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from unittest.mock import MagicMock, patch
 
 from tests.protocols import GmpTestCase
 
@@ -114,6 +115,21 @@ class GmpContextManagerTestCase(GmpTestCase):
         with self.assertRaises(GvmError):
             with self.gmp:
                 pass
+
+    @patch("gvm.protocols.gmp.Gmpv214")
+    def test_connect_disconnect(self, gmp_mock: MagicMock):
+        self.connection.read.return_value(
+            '<get_version_response status="200" status_text="OK">'
+            '<version>21.04</version>'
+            '</get_version_response>'
+        )
+
+        with self.gmp:
+            gmp_mock.assert_called_once()
+
+        mock_instance = gmp_mock.return_value
+        mock_instance.connect.assert_called_once()
+        mock_instance.disconnect.assert_called_once()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**What**:

When using the context manager on the Gmp class which determines the
supported GMP version ensure that the opened connection is closed when
leaving the context.

Fixes #659

**Why**:

Always close connections when using context manager.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/main/CHANGELOG.md) Entry
- [ ] Documentation
