### PR TITLE
Remove interface access for users

### DIFF
--- a/gvm/protocols/gmpv2110/__init__.py
+++ b/gvm/protocols/gmpv2110/__init__.py
@@ -127,9 +127,10 @@ from gvm.protocols.gmpv214.entities.targets import (
     AliveTest,
     TargetsMixin,
 )
-from gvm.protocols.gmpv214.entities.users import UsersMixin
 
 # NEW IN 2110
+from gvm.protocols.gmpv2110.entities.users import UsersMixin
+
 from gvm.protocols.gmpv2110.system.version import VersionMixin
 
 from gvm.connections import GvmConnection

--- a/gvm/protocols/gmpv2110/entities/users.py
+++ b/gvm/protocols/gmpv2110/entities/users.py
@@ -1,0 +1,191 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=arguments-differ, arguments-renamed
+
+from typing import Any, List, Optional
+
+from gvm.errors import RequiredArgument
+from gvm.protocols.gmpv214.entities.users import (
+    UsersMixin as Gmp214UsersMixin,
+    UserAuthType,
+)
+from gvm.utils import deprecation, to_comma_list, to_bool
+from gvm.xml import XmlCommand
+
+
+class UsersMixin(Gmp214UsersMixin):
+    def create_user(
+        self,
+        name: str,
+        *,
+        password: Optional[str] = None,
+        hosts: Optional[List[str]] = None,
+        hosts_allow: Optional[bool] = False,
+        ifaces: Any = None,
+        ifaces_allow: Any = None,
+        role_ids: Optional[List[str]] = None,
+    ) -> Any:
+        """Create a new user
+
+        Arguments:
+            name: Name of the user
+            password: Password of the user
+            hosts: A list of host addresses (IPs, DNS names)
+            hosts_allow: If True allow only access to passed hosts otherwise
+                deny access. Default is False for deny hosts.
+            ifaces: deprecated
+            ifaces_allow: deprecated
+            role_ids: A list of role UUIDs for the user
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not name:
+            raise RequiredArgument(
+                function=self.create_user.__name__, argument='name'
+            )
+
+        cmd = XmlCommand("create_user")
+        cmd.add_element("name", name)
+
+        if password:
+            cmd.add_element("password", password)
+
+        if hosts:
+            cmd.add_element(
+                "hosts",
+                to_comma_list(hosts),
+                attrs={"allow": to_bool(hosts_allow)},
+            )
+
+        if ifaces is not None:
+            major, minor = self.get_protocol_version()
+            deprecation(
+                "The ifaces parameter has been removed in GMP"
+                f" version {major}{minor}"
+            )
+
+        if ifaces_allow is not None:
+            major, minor = self.get_protocol_version()
+            deprecation(
+                "The ifaces_allow parameter has been removed in GMP"
+                f" version {major}{minor}"
+            )
+
+        if role_ids:
+            for role in role_ids:
+                cmd.add_element("role", attrs={"id": role})
+
+        return self._send_xml_command(cmd)
+
+    def modify_user(
+        self,
+        user_id: str = None,
+        *,
+        name: Optional[str] = None,
+        comment: Optional[str] = None,
+        password: Optional[str] = None,
+        auth_source: Optional[UserAuthType] = None,
+        role_ids: Optional[List[str]] = None,
+        hosts: Optional[List[str]] = None,
+        hosts_allow: Optional[bool] = False,
+        ifaces: Any = None,
+        ifaces_allow: Any = None,
+        group_ids: Optional[List[str]] = None,
+    ) -> Any:
+        """Modifies an existing user.
+
+        Most of the fields need to be supplied
+        for changing a single field even if no change is wanted for those.
+        Else empty values are inserted for the missing fields instead.
+
+        Arguments:
+            user_id: UUID of the user to be modified.
+            name: The new name for the user.
+            comment: Comment on the user.
+            password: The password for the user.
+            auth_source: Source allowed for authentication for this user.
+            roles_id: List of roles UUIDs for the user.
+            hosts: User access rules: List of hosts.
+            hosts_allow: Defines how the hosts list is to be interpreted.
+                If False (default) the list is treated as a deny list.
+                All hosts are allowed by default except those provided by
+                the hosts parameter. If True the list is treated as a
+                allow list. All hosts are denied by default except those
+                provided by the hosts parameter.
+            ifaces: deprecated
+            ifaces_allow: deprecated
+            group_ids: List of group UUIDs for the user.
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not user_id:
+            raise RequiredArgument(
+                function=self.modify_user.__name__, argument='user_id'
+            )
+
+        cmd = XmlCommand("modify_user")
+
+        cmd.set_attribute("user_id", user_id)
+
+        if name:
+            cmd.add_element("new_name", name)
+
+        if role_ids:
+            for role in role_ids:
+                cmd.add_element("role", attrs={"id": role})
+
+        if hosts:
+            cmd.add_element(
+                "hosts",
+                to_comma_list(hosts),
+                attrs={"allow": to_bool(hosts_allow)},
+            )
+
+        if ifaces is not None:
+            major, minor = self.get_protocol_version()
+            deprecation(
+                "The ifaces parameter has been removed in GMP"
+                f" version {major}{minor}"
+            )
+
+        if ifaces_allow is not None:
+            major, minor = self.get_protocol_version()
+            deprecation(
+                "The ifaces_allow parameter has been removed in GMP"
+                f" version {major}{minor}"
+            )
+
+        if comment:
+            cmd.add_element("comment", comment)
+
+        if password:
+            cmd.add_element("password", password)
+
+        if auth_source:
+            _xmlauthsrc = cmd.add_element("sources")
+            _xmlauthsrc.add_element("source", auth_source.value)
+
+        if group_ids:
+            _xmlgroups = cmd.add_element("groups")
+            for group_id in group_ids:
+                _xmlgroups.add_element("group", attrs={"id": group_id})
+
+        return self._send_xml_command(cmd)

--- a/tests/protocols/gmpv2110/entities/test_users.py
+++ b/tests/protocols/gmpv2110/entities/test_users.py
@@ -17,9 +17,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from ...gmpv2110 import Gmpv2110TestCase
-from .users import GmpModifyUserTestMixin
+from .users import GmpCreateUserTestMixin, GmpModifyUserTestMixin
 from ...gmpv208.entities.users import (
-    GmpCreateUserTestMixin,
     GmpCloneUserTestMixin,
     GmpDeleteUserTestMixin,
     GmpGetUsersTestMixin,

--- a/tests/protocols/gmpv2110/entities/users/__init__.py
+++ b/tests/protocols/gmpv2110/entities/users/__init__.py
@@ -16,4 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from .test_create_user import GmpCreateUserTestMixin
 from .test_modify_user import GmpModifyUserTestMixin

--- a/tests/protocols/gmpv2110/entities/users/test_create_user.py
+++ b/tests/protocols/gmpv2110/entities/users/test_create_user.py
@@ -1,0 +1,122 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest.mock import patch, call
+from gvm.errors import RequiredArgument
+
+
+class GmpCreateUserTestMixin:
+    def test_create_user_missing_name(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_user(name=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_user(name='')
+
+    def test_create_user(self):
+        self.gmp.create_user(name='foo')
+
+        self.connection.send.has_been_called_with(
+            '<create_user>' '<name>foo</name>' '</create_user>'
+        )
+
+    def test_create_user_with_password(self):
+        self.gmp.create_user(name='foo', password='bar')
+
+        self.connection.send.has_been_called_with(
+            '<create_user>'
+            '<name>foo</name>'
+            '<password>bar</password>'
+            '</create_user>'
+        )
+
+    def test_create_user_with_hosts(self):
+        self.gmp.create_user(name='foo', hosts=['h1', 'h2'], hosts_allow=True)
+
+        self.connection.send.has_been_called_with(
+            '<create_user>'
+            '<name>foo</name>'
+            '<hosts allow="1">h1,h2</hosts>'
+            '</create_user>'
+        )
+
+        self.gmp.create_user(name='foo', hosts=['h1', 'h2'])
+
+        self.connection.send.has_been_called_with(
+            '<create_user>'
+            '<name>foo</name>'
+            '<hosts allow="0">h1,h2</hosts>'
+            '</create_user>'
+        )
+
+        self.gmp.create_user(name='foo', hosts=['h1', 'h2'], hosts_allow=False)
+
+        self.connection.send.has_been_called_with(
+            '<create_user>'
+            '<name>foo</name>'
+            '<hosts allow="0">h1,h2</hosts>'
+            '</create_user>'
+        )
+
+    @patch('gvm.protocols.gmpv2110.entities.users.deprecation')
+    def test_create_user_with_ifaces(self, deprecation_mock):
+        self.gmp.create_user(name='foo', ifaces=['h1', 'h2'], ifaces_allow=True)
+
+        self.connection.send.has_been_called_with(
+            '<create_user>' '<name>foo</name>' '</create_user>'
+        )
+
+        self.gmp.create_user(name='foo', ifaces=['h1', 'h2'])
+
+        self.connection.send.has_been_called_with(
+            '<create_user>' '<name>foo</name>' '</create_user>'
+        )
+
+        self.gmp.create_user(
+            name='foo', ifaces=['h1', 'h2'], ifaces_allow=False
+        )
+
+        self.connection.send.has_been_called_with(
+            '<create_user>' '<name>foo</name>' '</create_user>'
+        )
+
+        # pylint: disable=line-too-long
+        deprecation_calls = [
+            call('The ifaces parameter has been removed in GMP version 2110'),
+            call(
+                'The ifaces_allow parameter has been removed in GMP version 2110'
+            ),
+            call('The ifaces parameter has been removed in GMP version 2110'),
+            call('The ifaces parameter has been removed in GMP version 2110'),
+            call(
+                'The ifaces_allow parameter has been removed in GMP version 2110'
+            ),
+        ]
+        # pylint: enable=line-too-long
+        deprecation_mock.assert_has_calls(deprecation_calls)
+
+    def test_create_user_with_role_ids(self):
+        self.gmp.create_user(name='foo', role_ids=['r1', 'r2'])
+
+        self.connection.send.has_been_called_with(
+            '<create_user>'
+            '<name>foo</name>'
+            '<role id="r1"/>'
+            '<role id="r2"/>'
+            '</create_user>'
+        )

--- a/tests/protocols/gmpv2110/entities/users/test_modify_user.py
+++ b/tests/protocols/gmpv2110/entities/users/test_modify_user.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+from unittest.mock import patch, call
 from gvm.errors import RequiredArgument
 from gvm.protocols.gmpv2110 import UserAuthType
 
@@ -156,43 +157,44 @@ class GmpModifyUserTestMixin:
             '</modify_user>'
         )
 
-    def test_modify_user_with_ifaces(self):
+    @patch('gvm.protocols.gmpv2110.entities.users.deprecation')
+    def test_modify_user_with_ifaces(self, deprecation_mock):
         self.gmp.modify_user(user_id='u1', ifaces=[])
 
         self.connection.send.has_been_called_with('<modify_user user_id="u1"/>')
 
-        self.gmp.modify_user(user_id='u1', ifaces=['foo'])
+        self.gmp.modify_user(user_id='u2', ifaces=['foo'])
 
-        self.connection.send.has_been_called_with(
-            '<modify_user user_id="u1">'
-            '<ifaces allow="0">foo</ifaces>'
-            '</modify_user>'
-        )
+        self.connection.send.has_been_called_with('<modify_user user_id="u2"/>')
 
-        self.gmp.modify_user(user_id='u1', ifaces=['foo', 'bar'])
+        self.gmp.modify_user(user_id='u3', ifaces=['foo', 'bar'])
 
-        self.connection.send.has_been_called_with(
-            '<modify_user user_id="u1">'
-            '<ifaces allow="0">foo,bar</ifaces>'
-            '</modify_user>'
-        )
+        self.connection.send.has_been_called_with('<modify_user user_id="u3"/>')
 
         self.gmp.modify_user(
-            user_id='u1', ifaces=['foo', 'bar'], ifaces_allow=False
+            user_id='u4', ifaces=['foo', 'bar'], ifaces_allow=False
         )
 
-        self.connection.send.has_been_called_with(
-            '<modify_user user_id="u1">'
-            '<ifaces allow="0">foo,bar</ifaces>'
-            '</modify_user>'
-        )
+        self.connection.send.has_been_called_with('<modify_user user_id="u4"/>')
 
         self.gmp.modify_user(
-            user_id='u1', ifaces=['foo', 'bar'], ifaces_allow=True
+            user_id='u5', ifaces=['foo', 'bar'], ifaces_allow=True
         )
 
-        self.connection.send.has_been_called_with(
-            '<modify_user user_id="u1">'
-            '<ifaces allow="1">foo,bar</ifaces>'
-            '</modify_user>'
-        )
+        self.connection.send.has_been_called_with('<modify_user user_id="u5"/>')
+
+        # pylint: disable=line-too-long
+        deprecation_calls = [
+            call('The ifaces parameter has been removed in GMP version 2110'),
+            call('The ifaces parameter has been removed in GMP version 2110'),
+            call('The ifaces parameter has been removed in GMP version 2110'),
+            call(
+                'The ifaces_allow parameter has been removed in GMP version 2110'
+            ),
+            call('The ifaces parameter has been removed in GMP version 2110'),
+            call(
+                'The ifaces_allow parameter has been removed in GMP version 2110'
+            ),
+        ]
+        # pylint: enable=line-too-long
+        deprecation_mock.assert_has_calls(deprecation_calls)


### PR DESCRIPTION
**What**:
Deprecate the ifaces and ifaces_allow parameters in create_user and modify_user. 
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:
The interface access feature for users is no longer supported.
<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/main/CHANGELOG.md) Entry "Remove: Deprecate ifaces and ifaces_allow parameters in user commands"
- [ ] Documentation
