### PR TITLE
Remove mentioning ALLINFO in the get_info_list method

### DIFF
--- a/gvm/protocols/gmpv208/entities/secinfo.py
+++ b/gvm/protocols/gmpv208/entities/secinfo.py
@@ -340,7 +340,7 @@ class SecInfoMixin:
 
         Arguments:
             info_type: Type must be either CERT_BUND_ADV, CPE, CVE,
-                DFN_CERT_ADV, OVALDEF, NVT or ALLINFO
+                DFN_CERT_ADV, OVALDEF or NVT
             filter_string: Filter term to use for the query
             filter_id: UUID of an existing filter to use for the query
             name: Name or identifier of the requested information


### PR DESCRIPTION
**What**:

The secinfo type ALLINFO got removed with the GVM 20.08 release.
See https://github.com/greenbone/gvmd/releases/tag/v20.8.0 for the
changelog of gvmd in this release.

Fixes #699

**Why**:

ALLINFO is obsolete.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/main/CHANGELOG.md) Entry
- [ ] Documentation
