### PR TITLE
Fix: Unwrap SSL socket before closing transport socket.

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -467,6 +467,16 @@ class TLSConnection(GvmConnection):
         self._socket = self._new_socket()
         self._socket.connect((self.hostname, int(self.port)))
 
+        
+    def disconnect(self):
+        """Close the SSL layer then disconnect from the remote server"""
+        try:
+            if self._socket is not None:
+                self._socket = self._socket.unwrap()
+        except OSError as e:
+            logger.debug("Connection closing error: %s", e)
+        return super(TLSConnection, self).disconnect()
+
 
 class UnixSocketConnection(GvmConnection):
     """

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -467,7 +467,6 @@ class TLSConnection(GvmConnection):
         self._socket = self._new_socket()
         self._socket.connect((self.hostname, int(self.port)))
 
-        
     def disconnect(self):
         """Close the SSL layer then disconnect from the remote server"""
         try:


### PR DESCRIPTION
Unwrap the SSL socket before closing the underlying transport socket instead of just closing SSL socket, to avoid yielding a "The TLS connection was non-properly terminated" warning in gvmd.log  on disconnect.

**What**:

Performing proper disconnect of a TLS connection to skip log warnings from `gvmd`.

**Why**:

`TLSConnection` uses a transport socket and TLS socket wrapped on top of it. When disconnecting, the TLS socket was simply closed. Such behavior caused a log warning on the `gvmd` side:
```
md   main:WARNING:2022-05-19 14h13.51 UTC:18703: read_from_client_tls: failed to read from client: The TLS connection was non-properly terminated.
```

**How**:

In the change, on disconnect,  `unwrap()` is called first on the TLS socket that closes it and returns the underlying transport socket, then the underlying socket can be closed normally and no warning from the `gvmd` server is generated.

I tested it using following snippet and observing tail of `gvmd.log`:

```python
from gvm.connections import TLSConnection
from gvm.transforms import EtreeCheckCommandTransform
from gvm.protocols.gmp import Gmp

conn = TLSConnection(hostname='127.0.0.1', port=9390, timeout=900)
transform=EtreeCheckCommandTransform()

with Gmp(connection=conn, transform=transform) as gmp:
    gmp.get_version()
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests  (N/A - needs `gvmd` to be tested)
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/main/CHANGELOG.md) Improved socket handling for TLSConnection.disconnect()
- [ ] Documentation N/A
