### PR TITLE
Remove: OSP Scanner is deprecated with 22.04

### DIFF
--- a/gvm/protocols/gmpv224/__init__.py
+++ b/gvm/protocols/gmpv224/__init__.py
@@ -68,7 +68,6 @@ from gvm.protocols.gmpv208.entities.report_formats import (
 from gvm.protocols.gmpv208.entities.reports import ReportsMixin
 from gvm.protocols.gmpv208.entities.results import ResultsMixin
 from gvm.protocols.gmpv208.entities.roles import RolesMixin
-from gvm.protocols.gmpv208.entities.scan_configs import ScanConfigsMixin
 from gvm.protocols.gmpv208.entities.schedules import SchedulesMixin
 from gvm.protocols.gmpv208.entities.secinfo import InfoType, SecInfoMixin
 from gvm.protocols.gmpv208.entities.severity import SeverityLevel
@@ -93,8 +92,9 @@ from gvm.protocols.gmpv208.system.user_settings import UserSettingsMixin
 # NEW IN 214
 from gvm.protocols.gmpv214.entities.notes import NotesMixin
 from gvm.protocols.gmpv214.entities.overrides import OverridesMixin
-from gvm.protocols.gmpv214.entities.scanners import ScannersMixin, ScannerType
 from gvm.protocols.gmpv214.entities.targets import AliveTest, TargetsMixin
+from gvm.protocols.gmpv224.entities.scan_configs import ScanConfigsMixin
+from gvm.protocols.gmpv224.entities.scanners import ScannersMixin, ScannerType
 
 # NEW IN 224
 from gvm.protocols.gmpv224.entities.users import UsersMixin

--- a/gvm/protocols/gmpv224/entities/scan_configs.py
+++ b/gvm/protocols/gmpv224/entities/scan_configs.py
@@ -1,0 +1,595 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from typing import Any, List, Optional, Tuple
+
+from lxml.etree import XMLSyntaxError
+
+from gvm.errors import InvalidArgument, InvalidArgumentType, RequiredArgument
+from gvm.utils import add_filter, deprecation, is_list_like, to_base64, to_bool
+from gvm.xml import XmlCommand
+
+
+class ScanConfigsMixin:
+    def clone_scan_config(self, config_id: str) -> Any:
+        """Clone a scan config from an existing one
+
+        Arguments:
+            config_id: UUID of the existing scan config
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=self.clone_scan_config.__name__, argument="config_id"
+            )
+
+        cmd = XmlCommand("create_config")
+        cmd.add_element("copy", config_id)
+        return self._send_xml_command(cmd)
+
+    def create_scan_config(
+        self, config_id: str, name: str, *, comment: Optional[str] = None
+    ) -> Any:
+        """Create a new scan config
+
+        Arguments:
+            config_id: UUID of the existing scan config
+            name: Name of the new scan config
+            comment: A comment on the config
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not name:
+            raise RequiredArgument(
+                function=self.create_scan_config.__name__, argument="name"
+            )
+
+        if not config_id:
+            raise RequiredArgument(
+                function=self.create_scan_config.__name__, argument="config_id"
+            )
+
+        cmd = XmlCommand("create_config")
+        if comment is not None:
+            cmd.add_element("comment", comment)
+        cmd.add_element("copy", config_id)
+        cmd.add_element("name", name)
+        cmd.add_element("usage_type", "scan")
+        return self._send_xml_command(cmd)
+
+    def delete_scan_config(
+        self, config_id: str, *, ultimate: Optional[bool] = False
+    ) -> Any:
+        """Deletes an existing config
+
+        Arguments:
+            config_id: UUID of the config to be deleted.
+            ultimate: Whether to remove entirely, or to the trashcan.
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=self.delete_scan_config.__name__, argument="config_id"
+            )
+
+        cmd = XmlCommand("delete_config")
+        cmd.set_attribute("config_id", config_id)
+        cmd.set_attribute("ultimate", to_bool(ultimate))
+
+        return self._send_xml_command(cmd)
+
+    def get_scan_configs(
+        self,
+        *,
+        filter_string: Optional[str] = None,
+        filter_id: Optional[str] = None,
+        trash: Optional[bool] = None,
+        details: Optional[bool] = None,
+        families: Optional[bool] = None,
+        preferences: Optional[bool] = None,
+        tasks: Optional[bool] = None,
+    ) -> Any:
+        """Request a list of scan configs
+
+        Arguments:
+            filter_string: Filter term to use for the query
+            filter_id: UUID of an existing filter to use for the query
+            trash: Whether to get the trashcan scan configs instead
+            details: Whether to get config families, preferences, nvt selectors
+                and tasks.
+            families: Whether to include the families if no details are
+                requested
+            preferences: Whether to include the preferences if no details are
+                requested
+            tasks: Whether to get tasks using this config
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        cmd = XmlCommand("get_configs")
+        cmd.set_attribute("usage_type", "scan")
+
+        add_filter(cmd, filter_string, filter_id)
+
+        if trash is not None:
+            cmd.set_attribute("trash", to_bool(trash))
+
+        if details is not None:
+            cmd.set_attribute("details", to_bool(details))
+
+        if families is not None:
+            cmd.set_attribute("families", to_bool(families))
+
+        if preferences is not None:
+            cmd.set_attribute("preferences", to_bool(preferences))
+
+        if tasks is not None:
+            cmd.set_attribute("tasks", to_bool(tasks))
+
+        return self._send_xml_command(cmd)
+
+    def get_scan_config(
+        self, config_id: str, *, tasks: Optional[bool] = None
+    ) -> Any:
+        """Request a single scan config
+
+        Arguments:
+            config_id: UUID of an existing scan config
+            tasks: Whether to get tasks using this config
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=self.get_scan_config.__name__, argument="config_id"
+            )
+
+        cmd = XmlCommand("get_configs")
+        cmd.set_attribute("config_id", config_id)
+
+        cmd.set_attribute("usage_type", "scan")
+
+        if tasks is not None:
+            cmd.set_attribute("tasks", to_bool(tasks))
+
+        # for single entity always request all details
+        cmd.set_attribute("details", "1")
+
+        return self._send_xml_command(cmd)
+
+    def get_scan_config_preferences(
+        self, *, nvt_oid: Optional[str] = None, config_id: Optional[str] = None
+    ) -> Any:
+        """Request a list of scan_config preferences
+
+        When the command includes a config_id attribute, the preference element
+        includes the preference name, type and value, and the NVT to which the
+        preference applies.
+        If the command includes a config_id and an nvt_oid, the preferences for
+        the given nvt in the config will be shown.
+
+        Arguments:
+            nvt_oid: OID of nvt
+            config_id: UUID of scan config of which to show preference values
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        cmd = XmlCommand("get_preferences")
+
+        if nvt_oid:
+            cmd.set_attribute("nvt_oid", nvt_oid)
+
+        if config_id:
+            cmd.set_attribute("config_id", config_id)
+
+        return self._send_xml_command(cmd)
+
+    def get_scan_config_preference(
+        self,
+        name: str,
+        *,
+        nvt_oid: Optional[str] = None,
+        config_id: Optional[str] = None,
+    ) -> Any:
+        """Request a nvt preference
+
+        Arguments:
+            name: name of a particular preference
+            nvt_oid: OID of nvt
+            config_id: UUID of scan config of which to show preference values
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        cmd = XmlCommand("get_preferences")
+
+        if not name:
+            raise RequiredArgument(
+                function=self.get_scan_config_preference.__name__,
+                argument="name",
+            )
+
+        cmd.set_attribute("preference", name)
+
+        if nvt_oid:
+            cmd.set_attribute("nvt_oid", nvt_oid)
+
+        if config_id:
+            cmd.set_attribute("config_id", config_id)
+
+        return self._send_xml_command(cmd)
+
+    def import_scan_config(self, config: str) -> Any:
+        """Import a scan config from XML
+
+        Arguments:
+            config: Scan Config XML as string to import. This XML must
+                contain a :code:`<get_configs_response>` root element.
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not config:
+            raise RequiredArgument(
+                function=self.import_scan_config.__name__, argument="config"
+            )
+
+        cmd = XmlCommand("create_config")
+
+        try:
+            cmd.append_xml_str(config)
+        except XMLSyntaxError as e:
+            raise InvalidArgument(
+                function=self.import_scan_config.__name__, argument="config"
+            ) from e
+
+        return self._send_xml_command(cmd)
+
+    def modify_scan_config_set_nvt_preference(
+        self,
+        config_id: str,
+        name: str,
+        nvt_oid: str,
+        *,
+        value: Optional[str] = None,
+    ) -> Any:
+        """Modifies the nvt preferences of an existing scan config.
+
+        Arguments:
+            config_id: UUID of scan config to modify.
+            name: Name for nvt preference to change.
+            nvt_oid: OID of the NVT associated with preference to modify
+            value: New value for the preference. None to delete the preference
+                and to use the default instead.
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=self.modify_scan_config_set_nvt_preference.__name__,
+                argument="config_id",
+            )
+
+        if not nvt_oid:
+            raise RequiredArgument(
+                function=self.modify_scan_config_set_nvt_preference.__name__,
+                argument="nvt_oid",
+            )
+
+        if not name:
+            raise RequiredArgument(
+                function=self.modify_scan_config_set_nvt_preference.__name__,
+                argument="name",
+            )
+
+        cmd = XmlCommand("modify_config")
+        cmd.set_attribute("config_id", str(config_id))
+
+        _xmlpref = cmd.add_element("preference")
+
+        _xmlpref.add_element("nvt", attrs={"oid": nvt_oid})
+        _xmlpref.add_element("name", name)
+
+        if value:
+            _xmlpref.add_element("value", to_base64(value))
+
+        return self._send_xml_command(cmd)
+
+    def modify_scan_config_set_name(self, config_id: str, name: str) -> Any:
+        """Modifies the name of an existing scan config
+
+        Arguments:
+            config_id: UUID of scan config to modify.
+            name: New name for the config.
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=self.modify_scan_config_set_name.__name__,
+                argument="config_id",
+            )
+
+        if not name:
+            raise RequiredArgument(
+                function=self.modify_scan_config_set_name.__name__,
+                argument="name",
+            )
+
+        cmd = XmlCommand("modify_config")
+        cmd.set_attribute("config_id", str(config_id))
+
+        cmd.add_element("name", name)
+
+        return self._send_xml_command(cmd)
+
+    def modify_scan_config_set_comment(
+        self, config_id: str, *, comment: Optional[str] = None
+    ) -> Any:
+        """Modifies the comment of an existing scan config
+
+        Arguments:
+            config_id: UUID of scan config to modify.
+            comment: Comment to set on a config. Default is an
+                empty comment and the previous comment will be
+                removed.
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=self.modify_scan_config_set_comment.__name__,
+                argument="config_id argument",
+            )
+
+        cmd = XmlCommand("modify_config")
+        cmd.set_attribute("config_id", str(config_id))
+        if not comment:
+            comment = ""
+        cmd.add_element("comment", comment)
+
+        return self._send_xml_command(cmd)
+
+    def modify_scan_config_set_scanner_preference(
+        self, config_id: str, name: str, *, value: Optional[str] = None
+    ) -> Any:
+        """Modifies the scanner preferences of an existing scan config
+
+        Arguments:
+            config_id: UUID of scan config to modify.
+            name: Name of the scanner preference to change
+            value: New value for the preference. None to delete the preference
+                and to use the default instead.
+
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=(
+                    self.modify_scan_config_set_scanner_preference.__name__
+                ),
+                argument="config_id",
+            )
+
+        if not name:
+            raise RequiredArgument(
+                function=(
+                    self.modify_scan_config_set_scanner_preference.__name__
+                ),
+                argument="name argument",
+            )
+
+        cmd = XmlCommand("modify_config")
+        cmd.set_attribute("config_id", str(config_id))
+
+        _xmlpref = cmd.add_element("preference")
+
+        _xmlpref.add_element("name", name)
+
+        if value:
+            _xmlpref.add_element("value", to_base64(value))
+
+        return self._send_xml_command(cmd)
+
+    def modify_scan_config_set_nvt_selection(
+        self, config_id: str, family: str, nvt_oids: List[str]
+    ) -> Any:
+        """Modifies the selected nvts of an existing scan config
+
+        The manager updates the given family in the config to include only the
+        given NVTs.
+
+        Arguments:
+            config_id: UUID of scan config to modify.
+            family: Name of the NVT family to include NVTs from
+            nvt_oids: List of NVTs to select for the family.
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=self.modify_scan_config_set_nvt_selection.__name__,
+                argument="config_id",
+            )
+
+        if not family:
+            raise RequiredArgument(
+                function=self.modify_scan_config_set_nvt_selection.__name__,
+                argument="family argument",
+            )
+
+        if not is_list_like(nvt_oids):
+            raise InvalidArgumentType(
+                function=self.modify_scan_config_set_nvt_selection.__name__,
+                argument="nvt_oids",
+                arg_type="list",
+            )
+
+        cmd = XmlCommand("modify_config")
+        cmd.set_attribute("config_id", str(config_id))
+
+        _xmlnvtsel = cmd.add_element("nvt_selection")
+        _xmlnvtsel.add_element("family", family)
+
+        for nvt in nvt_oids:
+            _xmlnvtsel.add_element("nvt", attrs={"oid": nvt})
+
+        return self._send_xml_command(cmd)
+
+    def modify_scan_config_set_family_selection(
+        self,
+        config_id: str,
+        families: List[Tuple[str, bool, bool]],
+        *,
+        auto_add_new_families: Optional[bool] = True,
+    ) -> Any:
+        """
+        Selected the NVTs of a scan config at a family level.
+
+        Arguments:
+            config_id: UUID of scan config to modify.
+            families: A list of tuples (str, bool, bool):
+                str: the name of the NVT family selected,
+                bool: add new NVTs  to the family automatically,
+                bool: include all NVTs from the family
+            auto_add_new_families: Whether new families should be added to the
+                scan config automatically. Default: True.
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=self.modify_scan_config_set_family_selection.__name__,
+                argument="config_id",
+            )
+
+        if not is_list_like(families):
+            raise InvalidArgumentType(
+                function=self.modify_scan_config_set_family_selection.__name__,
+                argument="families",
+                arg_type="list",
+            )
+
+        cmd = XmlCommand("modify_config")
+        cmd.set_attribute("config_id", str(config_id))
+
+        _xmlfamsel = cmd.add_element("family_selection")
+        _xmlfamsel.add_element("growing", to_bool(auto_add_new_families))
+
+        for family in families:
+            _xmlfamily = _xmlfamsel.add_element("family")
+            _xmlfamily.add_element("name", family[0])
+
+            if len(family) != 3:
+                raise InvalidArgument(
+                    "Family must be a tuple of 3. (str, bool, bool)"
+                )
+
+            if not isinstance(family[1], bool) or not isinstance(
+                family[2], bool
+            ):
+                raise InvalidArgumentType(
+                    function=(
+                        self.modify_scan_config_set_family_selection.__name__
+                    ),
+                    argument="families",
+                    arg_type="[tuple(str, bool, bool)]",
+                )
+
+            _xmlfamily.add_element("all", to_bool(family[2]))
+            _xmlfamily.add_element("growing", to_bool(family[1]))
+
+        return self._send_xml_command(cmd)
+
+    def modify_scan_config(
+        self, config_id: str, selection: Optional[str] = None, **kwargs
+    ) -> Any:
+        """Modifies an existing scan config.
+
+        DEPRECATED. Please use *modify_scan_config_set_* methods instead.
+
+        modify_config has four modes to operate depending on the selection.
+
+        Arguments:
+            config_id: UUID of scan config to modify.
+            selection: one of 'scan_pref', 'nvt_pref', 'nvt_selection' or
+                'family_selection'
+            name: New name for preference.
+            value: New value for preference.
+            nvt_oids: List of NVTs associated with preference to modify.
+            family: Name of family to modify.
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not config_id:
+            raise RequiredArgument(
+                function=self.modify_scan_config.__name__,
+                argument="config_id argument",
+            )
+
+        if selection is None:
+            deprecation(
+                "Using modify_config to update the comment of a scan config is"
+                "deprecated. Please use modify_scan_config_set_comment instead."
+            )
+            return self.modify_scan_config_set_comment(
+                config_id, comment=kwargs.get("comment")
+            )
+
+        if selection not in (
+            "nvt_pref",
+            "scan_pref",
+            "family_selection",
+            "nvt_selection",
+        ):
+            raise InvalidArgument(
+                "selection must be one of nvt_pref, "
+                "scan_pref, family_selection or "
+                "nvt_selection"
+            )
+
+        if selection == "nvt_pref":
+            deprecation(
+                "Using modify_scan_config to update a nvt preference of a scan "
+                "config is deprecated. Please use "
+                "modify_scan_config_set_nvt_preference instead."
+            )
+            return self.modify_scan_config_set_nvt_preference(
+                config_id, **kwargs
+            )
+
+        if selection == "scan_pref":
+            deprecation(
+                "Using modify_scan_config to update a scanner preference of a "
+                "scan config is deprecated. Please use "
+                "modify_scan_config_set_scanner_preference instead."
+            )
+            return self.modify_scan_config_set_scanner_preference(
+                config_id, **kwargs
+            )
+
+        if selection == "nvt_selection":
+            deprecation(
+                "Using modify_scan_config to update a nvt selection of a "
+                "scan config is deprecated. Please use "
+                "modify_scan_config_set_nvt_selection instead."
+            )
+            return self.modify_scan_config_set_nvt_selection(
+                config_id, **kwargs
+            )
+
+        deprecation(
+            "Using modify_scan_config to update a family selection of a "
+            "scan config is deprecated. Please use "
+            "modify_scan_config_set_family_selection instead."
+        )
+        return self.modify_scan_config_set_family_selection(config_id, **kwargs)

--- a/gvm/protocols/gmpv224/entities/scanners.py
+++ b/gvm/protocols/gmpv224/entities/scanners.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from enum import Enum
+from typing import Any, Optional
+
+from gvm.errors import InvalidArgument, InvalidArgumentType, RequiredArgument
+from gvm.protocols.gmpv208.entities.scanners import (
+    ScannersMixin as Gmp208ScannersMixin,
+)
+from gvm.xml import XmlCommand
+
+
+class ScannerType(Enum):
+    """Enum for scanner type"""
+
+    # 1 was removed (OSP_SCANNER_TYPE).
+    OPENVAS_SCANNER_TYPE = "2"
+    CVE_SCANNER_TYPE = "3"
+    GREENBONE_SENSOR_SCANNER_TYPE = "5"
+
+    @classmethod
+    def from_string(
+        cls,
+        scanner_type: Optional[str],
+    ) -> Optional["ScannerType"]:
+        """Convert a scanner type string to an actual ScannerType instance
+
+        Arguments:
+            scanner_type: Scanner type string to convert to a ScannerType
+        """
+        if not scanner_type:
+            return None
+
+        scanner_type = scanner_type.lower()
+
+        if (
+            scanner_type == cls.OPENVAS_SCANNER_TYPE.value
+            or scanner_type == "openvas"
+        ):
+            return cls.OPENVAS_SCANNER_TYPE
+
+        if scanner_type == cls.CVE_SCANNER_TYPE.value or scanner_type == "cve":
+            return cls.CVE_SCANNER_TYPE
+
+        if (
+            scanner_type == cls.GREENBONE_SENSOR_SCANNER_TYPE.value
+            or scanner_type == "greenbone"
+        ):
+            return cls.GREENBONE_SENSOR_SCANNER_TYPE
+
+        raise InvalidArgument(
+            argument="scanner_type", function=cls.from_string.__name__
+        )
+
+
+class ScannersMixin(Gmp208ScannersMixin):
+    # Override bc. of ScannerType (?)
+
+    def create_scanner(
+        self,
+        name: str,
+        host: str,
+        port: int,
+        scanner_type: ScannerType,
+        credential_id: str,
+        *,
+        ca_pub: Optional[str] = None,
+        comment: Optional[str] = None,
+    ) -> Any:
+        """Create a new scanner
+
+        Arguments:
+            name: Name of the scanner
+            host: The host of the scanner
+            port: The port of the scanner
+            scanner_type: Type of the scanner.
+            credential_id: UUID of client certificate credential for the
+                scanner
+            ca_pub: Certificate of CA to verify scanner certificate
+            comment: Comment for the scanner
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not name:
+            raise RequiredArgument(
+                function=self.create_scanner.__name__, argument="name"
+            )
+
+        if not host:
+            raise RequiredArgument(
+                function=self.create_scanner.__name__, argument="host"
+            )
+
+        if not port:
+            raise RequiredArgument(
+                function=self.create_scanner.__name__, argument="port"
+            )
+
+        if not scanner_type:
+            raise RequiredArgument(
+                function=self.create_scanner.__name__, argument="scanner_type"
+            )
+
+        if not credential_id:
+            raise RequiredArgument(
+                function=self.create_scanner.__name__, argument="credential_id"
+            )
+
+        if not isinstance(scanner_type, ScannerType):
+            raise InvalidArgumentType(
+                function=self.create_scanner.__name__,
+                argument="scanner_type",
+                arg_type=ScannerType.__name__,
+            )
+
+        cmd = XmlCommand("create_scanner")
+        cmd.add_element("name", name)
+        cmd.add_element("host", host)
+        cmd.add_element("port", str(port))
+        cmd.add_element("type", scanner_type.value)
+
+        if ca_pub:
+            cmd.add_element("ca_pub", ca_pub)
+
+        cmd.add_element("credential", attrs={"id": str(credential_id)})
+
+        if comment:
+            cmd.add_element("comment", comment)
+
+        return self._send_xml_command(cmd)
+
+    def modify_scanner(
+        self,
+        scanner_id: str,
+        *,
+        scanner_type: Optional[ScannerType] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        comment: Optional[str] = None,
+        name: Optional[str] = None,
+        ca_pub: Optional[str] = None,
+        credential_id: Optional[str] = None,
+    ) -> Any:
+        """Modifies an existing scanner.
+
+        Arguments:
+            scanner_id: UUID of scanner to modify.
+            scanner_type: New type of the Scanner.
+            host: Host of the scanner.
+            port: Port of the scanner.
+            comment: Comment on scanner.
+            name: Name of scanner.
+            ca_pub: Certificate of CA to verify scanner's certificate.
+            credential_id: UUID of the client certificate credential for the
+                Scanner.
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not scanner_id:
+            raise RequiredArgument(
+                function=self.modify_scanner.__name__,
+                argument="scanner_id argument",
+            )
+
+        cmd = XmlCommand("modify_scanner")
+        cmd.set_attribute("scanner_id", scanner_id)
+
+        if scanner_type is not None:
+            if not isinstance(scanner_type, ScannerType):
+                raise InvalidArgumentType(
+                    function=self.modify_scanner.__name__,
+                    argument="scanner_type",
+                    arg_type=ScannerType.__name__,
+                )
+
+            cmd.add_element("type", scanner_type.value)
+
+        if host:
+            cmd.add_element("host", host)
+
+        if port:
+            cmd.add_element("port", str(port))
+
+        if comment:
+            cmd.add_element("comment", comment)
+
+        if name:
+            cmd.add_element("name", name)
+
+        if ca_pub:
+            cmd.add_element("ca_pub", ca_pub)
+
+        if credential_id:
+            cmd.add_element("credential", attrs={"id": str(credential_id)})
+
+        return self._send_xml_command(cmd)

--- a/tests/protocols/gmpv224/entities/scan_configs/__init__.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/__init__.py
@@ -1,0 +1,47 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from .test_clone_scan_config import GmpCloneScanConfigTestMixin
+from .test_create_scan_config import GmpCreateScanConfigTestMixin
+from .test_delete_scan_config import GmpDeleteScanConfigTestMixin
+from .test_get_scan_config import GmpGetScanConfigTestMixin
+from .test_get_scan_config_preference import GmpGetScanConfigPreferenceTestMixin
+from .test_get_scan_config_preferences import (
+    GmpGetScanConfigPreferencesTestMixin,
+)
+from .test_get_scan_configs import GmpGetScanConfigsTestMixin
+from .test_import_scan_config import GmpImportScanConfigTestMixin
+from .test_modify_scan_config import GmpModifyScanConfigTestMixin
+from .test_modify_scan_config_set_comment import (
+    GmpModifyScanConfigSetCommentTestMixin,
+)
+from .test_modify_scan_config_set_family_selection import (
+    GmpModifyScanConfigSetFamilySelectionTestMixin,
+)
+from .test_modify_scan_config_set_name import (
+    GmpModifyScanConfigSetNameTestMixin,
+)
+from .test_modify_scan_config_set_nvt_preference import (
+    GmpModifyScanConfigSetNvtPreferenceTestMixin,
+)
+from .test_modify_scan_config_set_nvt_selection import (
+    GmpModifyScanConfigSetNvtSelectionTestMixin,
+)
+from .test_modify_scan_config_set_scanner_preference import (
+    GmpModifyScanConfigSetScannerPreferenceTestMixin,
+)

--- a/tests/protocols/gmpv224/entities/scan_configs/test_clone_scan_config.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_clone_scan_config.py
@@ -1,0 +1,35 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import RequiredArgument
+
+
+class GmpCloneScanConfigTestMixin:
+    def test_clone(self):
+        self.gmp.clone_scan_config("a1")
+
+        self.connection.send.has_been_called_with(
+            "<create_config><copy>a1</copy></create_config>"
+        )
+
+    def test_missing_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.clone_scan_config("")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.clone_scan_config(None)

--- a/tests/protocols/gmpv224/entities/scan_configs/test_create_scan_config.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_create_scan_config.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import RequiredArgument
+
+
+class GmpCreateScanConfigTestMixin:
+    def test_create_scan_config(self):
+        self.gmp.create_scan_config("a1", "foo")
+
+        self.connection.send.has_been_called_with(
+            "<create_config>"
+            "<copy>a1</copy>"
+            "<name>foo</name>"
+            "<usage_type>scan</usage_type>"
+            "</create_config>"
+        )
+
+    def test_create_scan_config_with_comment(self):
+        self.gmp.create_scan_config("a1", "foo", comment="comment")
+
+        self.connection.send.has_been_called_with(
+            "<create_config>"
+            "<comment>comment</comment>"
+            "<copy>a1</copy>"
+            "<name>foo</name>"
+            "<usage_type>scan</usage_type>"
+            "</create_config>"
+        )
+
+    def test_create_scan_config_missing_scan_config_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scan_config(config_id="", name="foo")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scan_config(config_id=None, name="foo")
+
+    def test_create_scan_config_missing_name(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scan_config(config_id="c1", name=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_scan_config(config_id="c1", name="")

--- a/tests/protocols/gmpv224/entities/scan_configs/test_delete_scan_config.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_delete_scan_config.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import GvmError
+
+
+class GmpDeleteScanConfigTestMixin:
+    def test_delete_scan_config(self):
+        self.gmp.delete_scan_config("a1")
+
+        self.connection.send.has_been_called_with(
+            '<delete_config config_id="a1" ultimate="0"/>'
+        )
+
+    def test_delete_scan_config_ultimate(self):
+        self.gmp.delete_scan_config("a1", ultimate=True)
+
+        self.connection.send.has_been_called_with(
+            '<delete_config config_id="a1" ultimate="1"/>'
+        )
+
+    def test_delete_scan_config_missing_scan_config_id(self):
+        with self.assertRaises(GvmError):
+            self.gmp.delete_scan_config(None)
+
+        with self.assertRaises(GvmError):
+            self.gmp.delete_scan_config("")

--- a/tests/protocols/gmpv224/entities/scan_configs/test_get_scan_config.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_get_scan_config.py
@@ -1,0 +1,43 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import GvmError
+
+
+class GmpGetScanConfigTestMixin:
+    def test_get_scan_config(self):
+        self.gmp.get_scan_config("a1")
+
+        self.connection.send.has_been_called_with(
+            '<get_configs config_id="a1" usage_type="scan" details="1"/>'
+        )
+
+    def test_get_scan_config_with_tasks(self):
+        self.gmp.get_scan_config("a1", tasks=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs config_id="a1" usage_type="scan" '
+            'tasks="1" details="1"/>'
+        )
+
+    def test_get_scan_config_fail_without_scan_config_id(self):
+        with self.assertRaises(GvmError):
+            self.gmp.get_scan_config(None)
+
+        with self.assertRaises(GvmError):
+            self.gmp.get_scan_config("")

--- a/tests/protocols/gmpv224/entities/scan_configs/test_get_scan_config_preference.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_get_scan_config_preference.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import RequiredArgument
+
+
+class GmpGetScanConfigPreferenceTestMixin:
+    def test_get_preference(self):
+        self.gmp.get_scan_config_preference(name="foo")
+
+        self.connection.send.has_been_called_with(
+            '<get_preferences preference="foo"/>'
+        )
+
+    def test_get_scan_config_preference_missing_name(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_scan_config_preference(name=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_scan_config_preference(name="")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_scan_config_preference("")
+
+    def test_get_scan_config_preference_with_nvt_oid(self):
+        self.gmp.get_scan_config_preference(name="foo", nvt_oid="oid")
+
+        self.connection.send.has_been_called_with(
+            '<get_preferences preference="foo" nvt_oid="oid"/>'
+        )
+
+    def test_get_scan_config_preference_with_config_id(self):
+        self.gmp.get_scan_config_preference(name="foo", config_id="c1")
+
+        self.connection.send.has_been_called_with(
+            '<get_preferences preference="foo" config_id="c1"/>'
+        )

--- a/tests/protocols/gmpv224/entities/scan_configs/test_get_scan_config_preferences.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_get_scan_config_preferences.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class GmpGetScanConfigPreferencesTestMixin:
+    def test_get_scan_config_preferences(self):
+        self.gmp.get_scan_config_preferences()
+
+        self.connection.send.has_been_called_with("<get_preferences/>")
+
+    def test_get_scan_config_preferences_with_nvt_oid(self):
+        self.gmp.get_scan_config_preferences(nvt_oid="oid")
+
+        self.connection.send.has_been_called_with(
+            '<get_preferences nvt_oid="oid"/>'
+        )
+
+    def test_get_scan_config_preferences_with_config_id(self):
+        self.gmp.get_scan_config_preferences(config_id="c1")
+
+        self.connection.send.has_been_called_with(
+            '<get_preferences config_id="c1"/>'
+        )

--- a/tests/protocols/gmpv224/entities/scan_configs/test_get_scan_configs.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_get_scan_configs.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+class GmpGetScanConfigsTestMixin:
+    def test_get_scan_configs_simple(self):
+        self.gmp.get_scan_configs()
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan"/>'
+        )
+
+    def test_get_scan_configs_with_filter_string(self):
+        self.gmp.get_scan_configs(filter_string="name=foo")
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" filter="name=foo"/>'
+        )
+
+    def test_get_scan_configs_with_filter_id(self):
+        self.gmp.get_scan_configs(filter_id="f1")
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" filt_id="f1"/>'
+        )
+
+    def test_get_scan_configs_from_trash(self):
+        self.gmp.get_scan_configs(trash=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" trash="1"/>'
+        )
+
+    def test_get_scan_configs_with_details(self):
+        self.gmp.get_scan_configs(details=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" details="1"/>'
+        )
+
+    def test_get_scan_configs_without_details(self):
+        self.gmp.get_scan_configs(details=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" details="0"/>'
+        )
+
+    def test_get_scan_configs_with_families(self):
+        self.gmp.get_scan_configs(families=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" families="1"/>'
+        )
+
+    def test_get_scan_configs_without_families(self):
+        self.gmp.get_scan_configs(families=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" families="0"/>'
+        )
+
+    def test_get_scan_configs_with_preferences(self):
+        self.gmp.get_scan_configs(preferences=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" preferences="1"/>'
+        )
+
+    def test_get_scan_configs_without_preferences(self):
+        self.gmp.get_scan_configs(preferences=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" preferences="0"/>'
+        )
+
+    def test_get_scan_configs_with_tasks(self):
+        self.gmp.get_scan_configs(tasks=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" tasks="1"/>'
+        )
+
+    def test_get_scan_configs_without_tasks(self):
+        self.gmp.get_scan_configs(tasks=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_configs usage_type="scan" tasks="0"/>'
+        )

--- a/tests/protocols/gmpv224/entities/scan_configs/test_import_scan_config.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_import_scan_config.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import InvalidArgument, RequiredArgument
+
+
+class GmpImportScanConfigTestMixin:
+
+    CONFIG_XML_STRING = (
+        '<get_configs_response status="200" status_text="OK">'
+        '<config id="c4aa21e4-23e6-4064-ae49-c0d425738a98">'
+        "<name>Foobar</name>"
+        "<comment>Foobar config</comment>"
+        "<creation_time>2018-11-09T10:48:03Z</creation_time>"
+        "<modification_time>2018-11-09T10:48:03Z</modification_time>"
+        "</config>"
+        "</get_configs_response>"
+    )
+
+    def test_import_scan_config(self):
+        self.gmp.import_scan_config(self.CONFIG_XML_STRING)
+
+        self.connection.send.has_been_called_with(
+            "<create_config>" f"{self.CONFIG_XML_STRING}" "</create_config>"
+        )
+
+    def test_import_missing_scan_config_xml(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.import_scan_config(None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.import_scan_config("")
+
+    def test_import_invalid_xml(self):
+        with self.assertRaises(InvalidArgument):
+            self.gmp.import_scan_config("abcdef")

--- a/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config.py
@@ -1,0 +1,150 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import warnings
+
+from gvm.errors import InvalidArgument, RequiredArgument
+
+
+class GmpModifyScanConfigTestMixin:
+    def test_modify_scan_config_invalid_selection(self):
+        with self.assertRaises(InvalidArgument):
+            self.gmp.modify_scan_config(config_id="c1", selection="foo")
+
+        with self.assertRaises(InvalidArgument):
+            self.gmp.modify_scan_config(config_id="c1", selection="")
+
+    def test_modify_scan_config_missing_config_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config(config_id=None, selection="nvt_pref")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config(config_id="", selection="nvt_pref")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config("", selection="nvt_pref")
+
+    def test_modify_scan_config_set_comment(self):
+        # pylint: disable=invalid-name
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            self.gmp.modify_scan_config(
+                config_id="c1", selection=None, comment="foo"
+            )
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<comment>foo</comment>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_nvt_pref(self):
+        # pylint: disable=invalid-name
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            self.gmp.modify_scan_config(
+                config_id="c1", selection="nvt_pref", nvt_oid="o1", name="foo"
+            )
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<preference>"
+            '<nvt oid="o1"/>'
+            "<name>foo</name>"
+            "</preference>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_scanner_pref(self):
+        # pylint: disable=invalid-name
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            self.gmp.modify_scan_config(
+                config_id="c1", selection="scan_pref", name="foo", value="bar"
+            )
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<preference>"
+            "<name>foo</name>"
+            "<value>YmFy</value>"
+            "</preference>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_nvt_selection(self):
+        # pylint: disable=invalid-name
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            self.gmp.modify_scan_config(
+                config_id="c1",
+                selection="nvt_selection",
+                nvt_oids=["o1"],
+                family="foo",
+            )
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<nvt_selection>"
+            "<family>foo</family>"
+            '<nvt oid="o1"/>'
+            "</nvt_selection>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_family_selection(self):
+        # pylint: disable=invalid-name
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+
+            self.gmp.modify_scan_config(
+                config_id="c1",
+                selection="family_selection",
+                families=[("foo", True, True)],
+            )
+
+            self.assertEqual(len(w), 1)
+            self.assertTrue(issubclass(w[0].category, DeprecationWarning))
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>1</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>1</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )

--- a/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_comment.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_comment.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import RequiredArgument
+
+
+class GmpModifyScanConfigSetCommentTestMixin:
+    def test_modify_scan_config_set_comment(self):
+        self.gmp.modify_scan_config_set_comment("c1")
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<comment></comment>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_comment("c1", comment="foo")
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<comment>foo</comment>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_comment("c1", comment=None)
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<comment></comment>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_comment_missing_config_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_comment(config_id=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_comment("")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_comment(config_id="")

--- a/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_family_selection.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_family_selection.py
@@ -1,0 +1,257 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import InvalidArgument, InvalidArgumentType, RequiredArgument
+
+
+class GmpModifyScanConfigSetFamilySelectionTestMixin:
+    def test_modify_scan_config_set_family_selection(self):
+        self.gmp.modify_scan_config_set_family_selection(
+            config_id="c1", families=[("foo", True, True)]
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>1</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>1</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_family_selection(
+            config_id="c1", families=[("foo", True, True), ("bar", True, True)]
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>1</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>1</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "<family>"
+            "<name>bar</name>"
+            "<all>1</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_family_selection(
+            config_id="c1", families=(("foo", True, True), ("bar", True, True))
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>1</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>1</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "<family>"
+            "<name>bar</name>"
+            "<all>1</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_family_selection(
+            config_id="c1",
+            families=[("foo", True, False), ("bar", False, True)],
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>1</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>0</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "<family>"
+            "<name>bar</name>"
+            "<all>1</all>"
+            "<growing>0</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_family_selection_missing_config_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_family_selection(
+                config_id=None, families=[("foo", True, True)]
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_family_selection(
+                config_id="", families=[("foo", True, True)]
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_family_selection(
+                "", [("foo", True)]
+            )
+
+    def test_modify_scan_config_set_family_selection_invalid_families(self):
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scan_config_set_family_selection(
+                config_id="c1", families=None
+            )
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scan_config_set_family_selection(
+                config_id="c1", families=""
+            )
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scan_config_set_family_selection("c1", "")
+
+    def test_modify_scan_config_set_family_selection_with_auto_add_new_families(
+        self,
+    ):
+        self.gmp.modify_scan_config_set_family_selection(
+            config_id="c1",
+            families=[("foo", True, True)],
+            auto_add_new_families=True,
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>1</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>1</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_family_selection(
+            config_id="c1",
+            families=[("foo", True, True)],
+            auto_add_new_families=False,
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>0</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>1</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_family_selection_with_auto_add_new_nvts(
+        self,
+    ):
+        self.gmp.modify_scan_config_set_family_selection(
+            config_id="c1", families=[("foo", True, True)]
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>1</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>1</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_family_selection(
+            config_id="c1", families=[("foo", False, True)]
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>1</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>1</all>"
+            "<growing>0</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_family_selection(
+            config_id="c1",
+            families=[("foo", False, True), ("bar", True, False)],
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<family_selection>"
+            "<growing>1</growing>"
+            "<family>"
+            "<name>foo</name>"
+            "<all>1</all>"
+            "<growing>0</growing>"
+            "</family>"
+            "<family>"
+            "<name>bar</name>"
+            "<all>0</all>"
+            "<growing>1</growing>"
+            "</family>"
+            "</family_selection>"
+            "</modify_config>"
+        )
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scan_config_set_family_selection(
+                config_id="c1", families=[("foo", "False", "True")]
+            )
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scan_config_set_family_selection(
+                config_id="c1", families=[("foo", True, None)]
+            )
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scan_config_set_family_selection(
+                config_id="c1", families=[("foo", "True", False)]
+            )
+
+        with self.assertRaises(InvalidArgument):
+            self.gmp.modify_scan_config_set_family_selection(
+                config_id="c1", families=[("foo",)]
+            )

--- a/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_name.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_name.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2020-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import RequiredArgument
+
+
+class GmpModifyScanConfigSetNameTestMixin:
+    def test_modify_scan_config_set_name(self):
+        self.gmp.modify_scan_config_set_name("c1", "foo")
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<name>foo</name>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_name_missing_config_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_name(config_id=None, name="name")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_name("", name="name")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_name(config_id="", name="name")
+
+    def test_modify_scan_config_set_name_missing_name(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_name(config_id="c", name="")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_name(config_id="c", name=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_name("c", "")

--- a/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_nvt_preference.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_nvt_preference.py
@@ -1,0 +1,107 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import RequiredArgument
+
+
+class GmpModifyScanConfigSetNvtPreferenceTestMixin:
+    def test_modify_scan_config_set_nvt_pref(self):
+        self.gmp.modify_scan_config_set_nvt_preference(
+            config_id="c1", nvt_oid="o1", name="foo"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<preference>"
+            '<nvt oid="o1"/>'
+            "<name>foo</name>"
+            "</preference>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_nvt_preference("c1", "foo", "o1")
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<preference>"
+            '<nvt oid="o1"/>'
+            "<name>foo</name>"
+            "</preference>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_nvt_pref_with_value(self):
+        self.gmp.modify_scan_config_set_nvt_preference(
+            "c1", "foo", nvt_oid="o1", value="bar"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<preference>"
+            '<nvt oid="o1"/>'
+            "<name>foo</name>"
+            "<value>YmFy</value>"
+            "</preference>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_nvt_pref_missing_nvt_oid(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_preference(
+                "c1", "foo", nvt_oid=None, value="bar"
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_preference(
+                "c1", "foo", nvt_oid="", value="bar"
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_preference(
+                "c1", "foo", "", value="bar"
+            )
+
+    def test_modify_scan_config_nvt_pref_missing_name(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_preference(
+                "c1", name=None, nvt_oid="o1", value="bar"
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_preference(
+                "c1", name="", nvt_oid="o1", value="bar"
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_preference(
+                "c1", "", nvt_oid="o1", value="bar"
+            )
+
+    def test_modify_scan_config_set_comment_missing_config_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_preference(
+                config_id=None, name="foo", nvt_oid="o1"
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_preference("", "foo", "o1")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_preference(
+                config_id="", name="foo", nvt_oid="o1"
+            )

--- a/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_nvt_selection.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_nvt_selection.py
@@ -1,0 +1,126 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import InvalidArgumentType, RequiredArgument
+
+
+class GmpModifyScanConfigSetNvtSelectionTestMixin:
+    def test_modify_scan_config_set_nvt_selection(self):
+        self.gmp.modify_scan_config_set_nvt_selection(
+            config_id="c1", family="foo", nvt_oids=["o1"]
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<nvt_selection>"
+            "<family>foo</family>"
+            '<nvt oid="o1"/>'
+            "</nvt_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_nvt_selection(
+            config_id="c1", family="foo", nvt_oids=["o1", "o2"]
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<nvt_selection>"
+            "<family>foo</family>"
+            '<nvt oid="o1"/>'
+            '<nvt oid="o2"/>'
+            "</nvt_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_nvt_selection("c1", "foo", ["o1"])
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<nvt_selection>"
+            "<family>foo</family>"
+            '<nvt oid="o1"/>'
+            "</nvt_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_nvt_selection("c1", "foo", ("o1", "o2"))
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<nvt_selection>"
+            "<family>foo</family>"
+            '<nvt oid="o1"/>'
+            '<nvt oid="o2"/>'
+            "</nvt_selection>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_nvt_selection(
+            config_id="c1", family="foo", nvt_oids=[]
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<nvt_selection>"
+            "<family>foo</family>"
+            "</nvt_selection>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_nvt_selection_missing_config_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_selection(
+                config_id=None, family="foo", nvt_oids=["o1"]
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_selection(
+                config_id="", family="foo", nvt_oids=["o1"]
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_selection("", "foo", ["o1"])
+
+    def test_modify_scan_config_set_nvt_selection_missing_family(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_selection(
+                config_id="c1", family=None, nvt_oids=["o1"]
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_selection(
+                config_id="c1", family="", nvt_oids=["o1"]
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_nvt_selection("c1", "", ["o1"])
+
+    def test_modify_scan_config_set_nvt_selection_invalid_nvt_oids(self):
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scan_config_set_nvt_selection(
+                config_id="c1", family="foo", nvt_oids=None
+            )
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scan_config_set_nvt_selection(
+                config_id="c1", family="foo", nvt_oids=""
+            )
+
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.modify_scan_config_set_nvt_selection("c1", "foo", "")

--- a/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_scanner_preference.py
+++ b/tests/protocols/gmpv224/entities/scan_configs/test_modify_scan_config_set_scanner_preference.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2018-2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import RequiredArgument
+
+
+class GmpModifyScanConfigSetScannerPreferenceTestMixin:
+    def test_modify_scan_config_set_scanner_pref(self):
+        self.gmp.modify_scan_config_set_scanner_preference(
+            config_id="c1", name="foo"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<preference>"
+            "<name>foo</name>"
+            "</preference>"
+            "</modify_config>"
+        )
+
+        self.gmp.modify_scan_config_set_scanner_preference("c1", "foo")
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<preference>"
+            "<name>foo</name>"
+            "</preference>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_set_scanner_pref_with_value(self):
+        self.gmp.modify_scan_config_set_scanner_preference(
+            "c1", "foo", value="bar"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<modify_config config_id="c1">'
+            "<preference>"
+            "<name>foo</name>"
+            "<value>YmFy</value>"
+            "</preference>"
+            "</modify_config>"
+        )
+
+    def test_modify_scan_config_scanner_pref_missing_name(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_scanner_preference(
+                "c1", name=None, value="bar"
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_scanner_preference(
+                "c1", name="", value="bar"
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_scanner_preference(
+                "c1", "", value="bar"
+            )
+
+    def test_modify_scan_config_set_comment_missing_config_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_scanner_preference(
+                config_id=None, name="foo"
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_scanner_preference("", "foo")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_scan_config_set_scanner_preference(
+                config_id="", name="foo"
+            )

--- a/tests/protocols/gmpv224/entities/scanners/test_create_scanner.py
+++ b/tests/protocols/gmpv224/entities/scanners/test_create_scanner.py
@@ -26,7 +26,7 @@ class GmpCreateScannerTestMixin:
             name="foo",
             host="localhost",
             port=1234,
-            scanner_type=ScannerType.OSP_SCANNER_TYPE,
+            scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
             credential_id="c1",
         )
 
@@ -35,7 +35,7 @@ class GmpCreateScannerTestMixin:
             "<name>foo</name>"
             "<host>localhost</host>"
             "<port>1234</port>"
-            "<type>1</type>"
+            "<type>2</type>"
             '<credential id="c1"/>'
             "</create_scanner>"
         )
@@ -46,7 +46,7 @@ class GmpCreateScannerTestMixin:
                 name=None,
                 host="localhost",
                 port=1234,
-                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
                 credential_id="c1",
             )
 
@@ -55,7 +55,7 @@ class GmpCreateScannerTestMixin:
                 name="",
                 host="localhost",
                 port=1234,
-                scanner_type="1",
+                scanner_type="2",
                 credential_id="c1",
             )
 
@@ -65,7 +65,7 @@ class GmpCreateScannerTestMixin:
                 name="foo",
                 host=None,
                 port=1234,
-                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
                 credential_id="c1",
             )
 
@@ -74,7 +74,7 @@ class GmpCreateScannerTestMixin:
                 name="foo",
                 host="",
                 port=1234,
-                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
                 credential_id="c1",
             )
 
@@ -84,7 +84,7 @@ class GmpCreateScannerTestMixin:
                 name="foo",
                 host="localhost",
                 port=None,
-                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
                 credential_id="c1",
             )
 
@@ -93,7 +93,7 @@ class GmpCreateScannerTestMixin:
                 name="foo",
                 host="localhost",
                 port="",
-                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
                 credential_id="c1",
             )
 
@@ -122,7 +122,7 @@ class GmpCreateScannerTestMixin:
                 name="foo",
                 host="localhost",
                 port=1234,
-                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
                 credential_id=None,
             )
 
@@ -131,7 +131,7 @@ class GmpCreateScannerTestMixin:
                 name="foo",
                 host="localhost",
                 port=1234,
-                scanner_type=ScannerType.OSP_SCANNER_TYPE,
+                scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
                 credential_id="",
             )
 
@@ -150,7 +150,7 @@ class GmpCreateScannerTestMixin:
                 name="foo",
                 host="localhost",
                 port=1234,
-                scanner_type=ScannerType.GMP_SCANNER_TYPE,  # pylint: disable=no-member
+                scanner_type=ScannerType.FOO,  # pylint: disable=no-member
                 credential_id="c1",
             )
 
@@ -169,7 +169,7 @@ class GmpCreateScannerTestMixin:
             host="localhost",
             port=1234,
             ca_pub="foo",
-            scanner_type=ScannerType.OSP_SCANNER_TYPE,
+            scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
             credential_id="c1",
         )
 
@@ -178,7 +178,7 @@ class GmpCreateScannerTestMixin:
             "<name>foo</name>"
             "<host>localhost</host>"
             "<port>1234</port>"
-            "<type>1</type>"
+            "<type>2</type>"
             "<ca_pub>foo</ca_pub>"
             '<credential id="c1"/>'
             "</create_scanner>"
@@ -189,7 +189,7 @@ class GmpCreateScannerTestMixin:
             name="foo",
             host="localhost",
             port=1234,
-            scanner_type=ScannerType.OSP_SCANNER_TYPE,
+            scanner_type=ScannerType.OPENVAS_SCANNER_TYPE,
             credential_id="c1",
             comment="bar",
         )
@@ -199,7 +199,7 @@ class GmpCreateScannerTestMixin:
             "<name>foo</name>"
             "<host>localhost</host>"
             "<port>1234</port>"
-            "<type>1</type>"
+            "<type>2</type>"
             '<credential id="c1"/>'
             "<comment>bar</comment>"
             "</create_scanner>"

--- a/tests/protocols/gmpv224/entities/scanners/test_modify_scanner.py
+++ b/tests/protocols/gmpv224/entities/scanners/test_modify_scanner.py
@@ -99,16 +99,6 @@ class GmpModifyScannerTestMixin:
 
     def test_modify_scanner_with_scanner_type(self):
         self.gmp.modify_scanner(
-            scanner_id="s1", scanner_type=ScannerType.OSP_SCANNER_TYPE
-        )
-
-        self.connection.send.has_been_called_with(
-            '<modify_scanner scanner_id="s1">'
-            "<type>1</type>"
-            "</modify_scanner>"
-        )
-
-        self.gmp.modify_scanner(
             scanner_id="s1", scanner_type=ScannerType.OPENVAS_SCANNER_TYPE
         )
 

--- a/tests/protocols/gmpv224/entities/test_scan_configs.py
+++ b/tests/protocols/gmpv224/entities/test_scan_configs.py
@@ -16,9 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from ...gmpv208.entities.scan_configs import (
+from ...gmpv224 import Gmpv224TestCase
+from ...gmpv224.entities.scan_configs import (
     GmpCloneScanConfigTestMixin,
-    GmpCreateScanConfigFromOSPScannerTestMixin,
     GmpCreateScanConfigTestMixin,
     GmpDeleteScanConfigTestMixin,
     GmpGetScanConfigsTestMixin,
@@ -31,9 +31,7 @@ from ...gmpv208.entities.scan_configs import (
     GmpModifyScanConfigSetNvtSelectionTestMixin,
     GmpModifyScanConfigSetScannerPreferenceTestMixin,
     GmpModifyScanConfigTestMixin,
-    GmpSyncScanConfigTestMixin,
 )
-from ...gmpv224 import Gmpv224TestCase
 
 
 class Gmpv224CloneScanConfigTestCase(
@@ -44,12 +42,6 @@ class Gmpv224CloneScanConfigTestCase(
 
 class Gmpv224CreateScanConfigTestCase(
     GmpCreateScanConfigTestMixin, Gmpv224TestCase
-):
-    pass
-
-
-class Gmpv224CreateScanConfigFromOSPScannerTestCase(
-    GmpCreateScanConfigFromOSPScannerTestMixin, Gmpv224TestCase
 ):
     pass
 
@@ -114,11 +106,5 @@ class Gmpv224ModifyScanConfigSetScannerPreferenceTestCase(
 
 class Gmpv224ModifyScanConfigTestCase(
     GmpModifyScanConfigTestMixin, Gmpv224TestCase
-):
-    pass
-
-
-class Gmpv224SyncScanConfigTestCase(
-    GmpSyncScanConfigTestMixin, Gmpv224TestCase
 ):
     pass

--- a/tests/protocols/gmpv224/enums/test_scanner_type.py
+++ b/tests/protocols/gmpv224/enums/test_scanner_type.py
@@ -33,13 +33,6 @@ class GetScannerTypeFromStringTestCase(unittest.TestCase):
         ct = ScannerType.from_string("")
         self.assertIsNone(ct)
 
-    def test_osp_scanner(self):
-        ct = ScannerType.from_string("1")
-        self.assertEqual(ct, ScannerType.OSP_SCANNER_TYPE)
-
-        ct = ScannerType.from_string("osp")
-        self.assertEqual(ct, ScannerType.OSP_SCANNER_TYPE)
-
     def test_openvas_scanner(self):
         ct = ScannerType.from_string("2")
         self.assertEqual(ct, ScannerType.OPENVAS_SCANNER_TYPE)


### PR DESCRIPTION
**What**:

Only 22.04:
* OSP Scanner has been removed from `ScannerTypeEnum`
* `sync_scan_config` API call has been removed
* `create_scan_config_from_scanner` has been removed

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* OSP Scanner is deprecated with 22.04

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/main/CHANGELOG.md) Entry
- [ ] Documentation
