### PR TITLE
Fix: Add missing API docs for GMP 22.4 class

### DIFF
--- a/docs/api/gmpv224.rst
+++ b/docs/api/gmpv224.rst
@@ -1,9 +1,9 @@
-.. _gmpv214:
+.. _gmpv224:
 
-GMP v21.4
+GMP v22.4
 ^^^^^^^^^
 
-.. automodule:: gvm.protocols.gmpv214
+.. automodule:: gvm.protocols.gmpv224
 
 Enums
 -----
@@ -11,97 +11,78 @@ Enums
 .. autoclass:: AlertCondition
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: AlertEvent
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: AlertMethod
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: AliveTest
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: CredentialFormat
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: CredentialType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: EntityType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: FeedType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: FilterType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: HostsOrdering
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: HelpFormat
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: InfoType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: PermissionSubjectType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: ScannerType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: PortRangeType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: SeverityLevel
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: SnmpAuthAlgorithm
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: SnmpPrivacyAlgorithm
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: TicketStatus
     :members:
     :undoc-members:
-    :noindex:
 
 Protocol
 --------

--- a/docs/api/protocols.rst
+++ b/docs/api/protocols.rst
@@ -10,6 +10,7 @@ Protocols
 
     gmpv208
     gmpv214
+    gmpv224
     ospv1
 
 Dynamic


### PR DESCRIPTION
**What**:

Add missing API docs for GMP 22.4 class

**Why**:

The API docs haven't been build for the 22.4 protocol class.

**How**:

`cd docs && poetry build html && firefox build/html/index.html` to check if the API docs are build now.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/main/CHANGELOG.md) Entry
- [x] Documentation
