### PR TITLE
Change: Update gvmd socket location to /run/gvmd/gvmd.sock

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -54,12 +54,12 @@ The following shows the process of a simple request in more detail.
 2. Specify the path to the Unix domain socket in the file system:
 
 .. note:: If **gvmd** is provided by a package of the distribution, it should
-    be ``/var/run/gvmd.sock``. If **gvmd** was built from source and did not set
+    be ``/run/gvmd/gvmd.sock``. If **gvmd** was built from source and did not set
     a prefix, the default path can be used by setting ``path = None``.
 
 .. code-block:: python
 
-    path = '/var/run/gvmd.sock'
+    path = '/run/gvmd/gvmd.sock'
 
 3. Create a connection and a gmp object:
 
@@ -89,7 +89,7 @@ Full Example
     from gvm.protocols.gmp import Gmp
 
     # path to unix socket
-    path = '/var/run/gvmd.sock'
+    path = '/run/gvmd/gvmd.sock'
     connection = UnixSocketConnection(path=path)
 
     # using the with statement to automatically connect and disconnect to gvmd
@@ -126,7 +126,7 @@ Step by Step
 
 .. code-block:: python
 
-    path = '/var/run/gvmd.sock'
+    path = '/run/gvmd/gvmd.sock'
     connection = UnixSocketConnection(path=path)
 
 3. In this case, an `Etree Element`_ should be obtained from the response to be able to
@@ -192,7 +192,7 @@ Full Example
     from gvm.protocols.gmp import Gmp
     from gvm.transforms import EtreeCheckCommandTransform
 
-    path = '/var/run/gvmd.sock'
+    path = '/run/gvmd/gvmd.sock'
     connection = UnixSocketConnection(path=path)
     transform = EtreeCheckCommandTransform()
 
@@ -336,7 +336,7 @@ Example using GMP:
     from gvm.connections import UnixSocketConnection, DebugConnection
     from gvm.protocols.gmp import Gmp
 
-    path = '/var/run/gvmd.sock'
+    path = '/run/gvmd/gvmd.sock'
     socketconnection = UnixSocketConnection(path=path)
     connection = DebugConnection(socketconnection)
 

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -40,7 +40,7 @@ BUF_SIZE = 16 * 1024
 DEFAULT_READ_TIMEOUT = 60  # in seconds
 DEFAULT_TIMEOUT = 60  # in seconds
 DEFAULT_GVM_PORT = 9390
-DEFAULT_UNIX_SOCKET_PATH = "/var/run/gvmd.sock"
+DEFAULT_UNIX_SOCKET_PATH = "/run/gvmd/gvmd.sock"
 DEFAULT_SSH_PORT = 22
 DEFAULT_SSH_USERNAME = "gmp"
 DEFAULT_SSH_PASSWORD = ""
@@ -475,11 +475,11 @@ class TLSConnection(GvmConnection):
 
 class UnixSocketConnection(GvmConnection):
     """
-    UNIX-Socket class to connect, read, write from a GVM server daemon via
-    direct communicating UNIX-Socket
+    UNIX-Socket class to connect, read, write from a daemon via direct
+    communicating UNIX-Socket
 
     Arguments:
-        path: Path to the socket. Default is "/var/run/gvmd.sock".
+        path: Path to the socket. Default is "/run/gvmd/gvmd.sock".
         timeout: Timeout in seconds for the connection. Default is 60 seconds.
     """
 


### PR DESCRIPTION
**What**:

Update gvmd socket location to /run/gvmd/gvmd.sock

**Why**:

With our current supported releases the gvmd socket is located at
/run/gvmd/gvmd.sock.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/python-gvm/blob/main/CHANGELOG.md) Entry
- [x] Documentation
