### PR TITLE
fix：the ssh port should not be constant

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -291,7 +291,7 @@ class SSHConnection(GvmConnection):
         """Get the remote host key for ssh connection"""
         try:
             tmp_socket = socketlib.socket()
-            tmp_socket.connect((self.hostname, 22))
+            tmp_socket.connect((self.hostname, self.port))
         except OSError as e:
             raise GvmError(
                 "Couldn't establish a connection to fetch the"


### PR DESCRIPTION
When I try to establish a connection to a non-22 port, it keeps failing, so I found this  /(ㄒoㄒ)/~~