### PR TITLE
Change: Add workaround for non-standard SSH ports

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -246,7 +246,11 @@ class SSHConnection(GvmConnection):
                 if self.port == 22:
                     hostkeys.add(self.hostname, key.get_name(), key)
                 elif self.port != 22:
-                    hostkeys.add("[" + self.hostname + "]:" + str(self.port), key.get_name(), key)
+                    hostkeys.add(
+                        "[" + self.hostname + "]:" + str(self.port),
+                        key.get_name(),
+                        key,
+                    )
                 # ask user if the key should be added permanently
                 print(
                     f"Do you want to add {self.hostname} "

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -245,7 +245,7 @@ class SSHConnection(GvmConnection):
             if add == "yes":
                 if self.port == DEFAULT_SSH_PORT:
                     hostkeys.add(self.hostname, key.get_name(), key)
-                elif self.port != 22:
+                elif self.port != DEFAULT_SSH_PORT:
                     hostkeys.add(
                         "[" + self.hostname + "]:" + str(self.port),
                         key.get_name(),

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -243,7 +243,10 @@ class SSHConnection(GvmConnection):
         add = input()
         while True:
             if add == "yes":
-                hostkeys.add(self.hostname, key.get_name(), key)
+                if self.port == 22:
+                    hostkeys.add(self.hostname, key.get_name(), key)
+                elif self.port != 22:
+                    hostkeys.add("[" + self.hostname + "]:" + str(self.port), key.get_name(), key)
                 # ask user if the key should be added permanently
                 print(
                     f"Do you want to add {self.hostname} "
@@ -331,12 +334,21 @@ class SSHConnection(GvmConnection):
                     f"the known_hosts file: {e}"
                 ) from None
         hostkeys = self._socket.get_host_keys()
-        if not hostkeys.lookup(self.hostname):
-            # Key not found, so connect to remote and fetch the key
-            # with the paramiko Transport protocol
-            key = self._get_remote_host_key()
+        # Switch based on SSH Port
+        if self.port == 22:
+            if not hostkeys.lookup(self.hostname):
+                # Key not found, so connect to remote and fetch the key
+                # with the paramiko Transport protocol
+                key = self._get_remote_host_key()
 
-            self._ssh_authentication_input_loop(hostkeys=hostkeys, key=key)
+                self._ssh_authentication_input_loop(hostkeys=hostkeys, key=key)
+        elif self.port != 22:
+            if not hostkeys.lookup("[" + self.hostname + "]:" + str(self.port)):
+                # Key not found, so connect to remote and fetch the key
+                # with the paramiko Transport protocol
+                key = self._get_remote_host_key()
+
+                self._ssh_authentication_input_loop(hostkeys=hostkeys, key=key)
 
     def connect(self) -> None:
         """


### PR DESCRIPTION
**What**:
This PR is to address #924 
I don't think this is the most elegent solution - it would be preferable to use Paramiko's handling of non-standard ports, but TBH, I can't decypher how they are doing it right now.
For now, this PR includes the workaround I've built to get my solution working.

What I don't think this PR will solve is hashed or salted hostnames.

**Why**:
To allow SSHConnection to connect on non-standard ports and store/resuse known_host entries.

**How**:
I've used local edits per the PR. Verfied using the script referenced in #924.
I've confirmed:

- Clear known_hosts, run script using Paramiko to add the host to the known_hosts file, then run SSHConnection = successful connection using the known_hosts file.
- Clear known_hosts, connect using SSHConnection, answer 'yes' to adding the server to known_hosts, disconnect and run again, second connection doesn't prompt to add to known_hosts = successful.

**Checklist**:
- [x] Tests
- [x] Conventional commit message
- [ ] Documentation - N/A
