### PR TITLE
Fix GitHub workflows and enable caching of python packages

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -24,6 +24,8 @@ jobs:
         with:
           packages: gvm tests
           version: ${{ matrix.python-version }}
+          poetry-version: "1.4.0"
+          cache: "true"
 
   test:
     name: Unit tests
@@ -42,6 +44,8 @@ jobs:
         uses: greenbone/actions/poetry@v2
         with:
           version: ${{ matrix.python-version }}
+          poetry-version: "1.4.0"
+          cache: "true"
       - name: Run unit tests
         run: poetry run python -m unittest
 
@@ -55,6 +59,8 @@ jobs:
         uses: greenbone/actions/coverage-python@v2
         with:
           version: "3.10"
+          poetry-version: "1.4.0"
+          cache: "true"
 
   build-docs:
     name: Build the documentation
@@ -64,7 +70,8 @@ jobs:
       - name: Install poetry and dependencies
         uses: greenbone/actions/poetry@v2
         with:
-          version: 3.9
+          poetry-version: "1.4.0"
+          cache: "true"
       - name: Build docs
         run: |
           cd docs

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Install poetry and dependencies
         uses: greenbone/actions/poetry@v2
         with:
-          version: "3.9"
+          poetry-version: "1.4.0"
+          cache: "true"
       - name: Build Documentation
         run: |
           cd docs && poetry run make html


### PR DESCRIPTION
## What

Fix GitHub workflows and enable caching of python packages

## Why

Currently the installation of packages with poetry 1.4.1 fails because of the furo sphinx theme package has some issue. Until that's fixed we stick with poetry 1.4.0.
