### PR TITLE
Add: Allow to query host and os details

### DIFF
--- a/gvm/protocols/gmpv208/entities/hosts.py
+++ b/gvm/protocols/gmpv208/entities/hosts.py
@@ -21,7 +21,7 @@ from enum import Enum
 from typing import Any, Optional
 
 from gvm.errors import InvalidArgument, RequiredArgument
-from gvm.utils import add_filter
+from gvm.utils import add_filter, to_bool
 from gvm.xml import XmlCommand
 
 
@@ -101,12 +101,14 @@ class HostsMixin:
         *,
         filter_string: Optional[str] = None,
         filter_id: Optional[str] = None,
+        details: Optional[bool] = None,
     ) -> Any:
         """Request a list of hosts
 
         Arguments:
             filter_string: Filter term to use for the query
             filter_id: UUID of an existing filter to use for the query
+            details: Whether to include additional information (e.g. tags)
 
         Returns:
             The response. See :py:meth:`send_command` for details.
@@ -118,13 +120,17 @@ class HostsMixin:
 
         add_filter(cmd, filter_string, filter_id)
 
+        if details is not None:
+            cmd.set_attribute("details", to_bool(details))
+
         return self._send_xml_command(cmd)
 
-    def get_host(self, host_id: str) -> Any:
+    def get_host(self, host_id: str, *, details: Optional[bool] = None) -> Any:
         """Request a single host
 
         Arguments:
             host_id: UUID of an existing host
+            details: Whether to include additional information (e.g. tags)
 
         Returns:
             The response. See :py:meth:`send_command` for details.
@@ -138,6 +144,9 @@ class HostsMixin:
 
         cmd.set_attribute("asset_id", host_id)
         cmd.set_attribute("type", "host")
+
+        if details is not None:
+            cmd.set_attribute("details", to_bool(details))
 
         return self._send_xml_command(cmd)
 

--- a/gvm/protocols/gmpv208/entities/operating_systems.py
+++ b/gvm/protocols/gmpv208/entities/operating_systems.py
@@ -19,7 +19,7 @@
 from typing import Any, Optional
 
 from gvm.errors import RequiredArgument
-from gvm.utils import add_filter
+from gvm.utils import add_filter, to_bool
 from gvm.xml import XmlCommand
 
 
@@ -50,12 +50,14 @@ class OperatingSystemsMixin:
         *,
         filter_string: Optional[str] = None,
         filter_id: Optional[str] = None,
+        details: Optional[bool] = None,
     ) -> Any:
         """Request a list of operating_systems
 
         Arguments:
             filter_string: Filter term to use for the query
             filter_id: UUID of an existing filter to use for the query
+            details: Whether to include additional information (e.g. tags)
 
         Returns:
             The response. See :py:meth:`send_command` for details.
@@ -67,13 +69,19 @@ class OperatingSystemsMixin:
 
         add_filter(cmd, filter_string, filter_id)
 
+        if details is not None:
+            cmd.set_attribute("details", to_bool(details))
+
         return self._send_xml_command(cmd)
 
-    def get_operating_system(self, operating_system_id: str) -> Any:
+    def get_operating_system(
+        self, operating_system_id: str, *, details: Optional[bool] = None
+    ) -> Any:
         """Request a single operating_system
 
         Arguments:
             operating_system_id: UUID of an existing operating_system
+            details: Whether to include additional information (e.g. tags)
 
         Returns:
             The response. See :py:meth:`send_command` for details.
@@ -88,6 +96,9 @@ class OperatingSystemsMixin:
 
         cmd.set_attribute("asset_id", operating_system_id)
         cmd.set_attribute("type", "os")
+
+        if details is not None:
+            cmd.set_attribute("details", to_bool(details))
 
         return self._send_xml_command(cmd)
 

--- a/tests/protocols/gmpv208/entities/hosts/test_get_host.py
+++ b/tests/protocols/gmpv208/entities/hosts/test_get_host.py
@@ -33,6 +33,19 @@ class GmpGetHostTestMixin:
             '<get_assets asset_id="a1" type="host"/>'
         )
 
+    def test_get_host_details(self):
+        self.gmp.get_host("a1", details=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_assets asset_id="a1" type="host" details="1"/>'
+        )
+
+        self.gmp.get_host("a1", details=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_assets asset_id="a1" type="host" details="0"/>'
+        )
+
     def test_get_host_missing_host_id(self):
         with self.assertRaises(RequiredArgument):
             self.gmp.get_host(

--- a/tests/protocols/gmpv208/entities/hosts/test_get_hosts.py
+++ b/tests/protocols/gmpv208/entities/hosts/test_get_hosts.py
@@ -23,6 +23,19 @@ class GmpGetHostsTestMixin:
 
         self.connection.send.has_been_called_with('<get_assets type="host"/>')
 
+    def test_get_hosts_details(self):
+        self.gmp.get_hosts(details=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_assets type="host" details="1"/>'
+        )
+
+        self.gmp.get_hosts(details=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_assets type="host" details="0"/>'
+        )
+
     def test_get_hosts_with_filter_string(self):
         self.gmp.get_hosts(filter_string="foo=bar")
 

--- a/tests/protocols/gmpv208/entities/operating_systems/test_get_operating_system.py
+++ b/tests/protocols/gmpv208/entities/operating_systems/test_get_operating_system.py
@@ -32,6 +32,18 @@ class GmpGetOperatingSystemTestMixin:
             '<get_assets asset_id="a1" type="os"/>'
         )
 
+    def test_get_operating_system_details(self):
+        self.gmp.get_operating_system("a1", details=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_assets asset_id="a1" type="os" details="1"/>'
+        )
+        self.gmp.get_operating_system("a1", details=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_assets asset_id="a1" type="os" details="0"/>'
+        )
+
     def test_get_asset_missing_operating_system_id(self):
         with self.assertRaises(RequiredArgument):
             self.gmp.get_operating_system(operating_system_id=None)

--- a/tests/protocols/gmpv208/entities/operating_systems/test_get_operating_systems.py
+++ b/tests/protocols/gmpv208/entities/operating_systems/test_get_operating_systems.py
@@ -23,6 +23,19 @@ class GmpGetOperatingSystemsTestMixin:
 
         self.connection.send.has_been_called_with('<get_assets type="os"/>')
 
+    def test_get_operating_systems_details(self):
+        self.gmp.get_operating_systems(details=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_assets type="os" details="1"/>'
+        )
+
+        self.gmp.get_operating_systems(details=False)
+
+        self.connection.send.has_been_called_with(
+            '<get_assets type="os" details="0"/>'
+        )
+
     def test_get_operating_systems_with_filter_string(self):
         self.gmp.get_operating_systems(filter_string="foo=bar")
 


### PR DESCRIPTION
## What

Allow to query host and os details

## Why

Add details argument to get_host, get_hosts, get_operating_system and get_operating_systems to allow querying the asset details.

## References

https://forum.greenbone.net/t/gvm-user-tags-missing-in-response-xml/14338

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


