### PR TITLE
Add: Readd get_nvts and get_nvt original calls

### DIFF
--- a/tests/protocols/gmpv208/entities/secinfo/test_get_nvt.py
+++ b/tests/protocols/gmpv208/entities/secinfo/test_get_nvt.py
@@ -42,3 +42,23 @@ class GmpGetNvtTestMixin:
 
         with self.assertRaises(RequiredArgument):
             self.gmp.get_nvt(nvt_id=None)
+
+    def test_get_extended_nvt_with_nvt_oid(self):
+        self.gmp.get_nvt(extended=True, nvt_id="nvt_oid")
+
+        self.connection.send.has_been_called_with(
+            (
+                '<get_nvts nvt_oid="nvt_oid" details="1" '
+                'preferences="1" preference_count="1"/>'
+            )
+        )
+
+    def test_get_extended_nvt_missing_nvt_oid(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_nvt(extended=True, nvt_id=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_nvt(extended=True, nvt_id="")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_nvt("", extended=True)

--- a/tests/protocols/gmpv208/entities/secinfo/test_get_nvts.py
+++ b/tests/protocols/gmpv208/entities/secinfo/test_get_nvts.py
@@ -18,7 +18,7 @@
 
 
 class GmpGetNvtListTestMixin:
-    def test_get_cpes(self):
+    def test_get_nvts(self):
         self.gmp.get_nvts()
 
         self.connection.send.has_been_called_with('<get_info type="NVT"/>')
@@ -55,4 +55,78 @@ class GmpGetNvtListTestMixin:
 
         self.connection.send.has_been_called_with(
             '<get_info type="NVT" details="0"/>'
+        )
+
+    def test_get_extended_nvts(self):
+        self.gmp.get_nvts(extended=True)
+
+        self.connection.send.has_been_called_with("<get_nvts/>")
+
+    def test_get_extended_nvts_with_details(self):
+        self.gmp.get_nvts(extended=True, details=True)
+
+        self.connection.send.has_been_called_with('<get_nvts details="1"/>')
+
+        self.gmp.get_nvts(extended=True, details=False)
+
+        self.connection.send.has_been_called_with('<get_nvts details="0"/>')
+
+    def test_get_extended_nvts_with_preferences(self):
+        self.gmp.get_nvts(extended=True, preferences=True)
+
+        self.connection.send.has_been_called_with('<get_nvts preferences="1"/>')
+
+        self.gmp.get_nvts(extended=True, preferences=False)
+
+        self.connection.send.has_been_called_with('<get_nvts preferences="0"/>')
+
+    def test_get_extended_nvts_with_preference_count(self):
+        self.gmp.get_nvts(extended=True, preference_count=True)
+
+        self.connection.send.has_been_called_with(
+            '<get_nvts preference_count="1"/>'
+        )
+
+    def test_get_extended_nvts_with_timeout(self):
+        self.gmp.get_nvts(extended=True, timeout=True)
+
+        self.connection.send.has_been_called_with('<get_nvts timeout="1"/>')
+
+        self.gmp.get_nvts(extended=True, timeout=False)
+
+        self.connection.send.has_been_called_with('<get_nvts timeout="0"/>')
+
+    def test_get_extended_nvts_with_config_id(self):
+        self.gmp.get_nvts(extended=True, config_id="config_id")
+
+        self.connection.send.has_been_called_with(
+            '<get_nvts config_id="config_id"/>'
+        )
+
+    def test_get_extended_nvts_with_preferences_config_id(self):
+        self.gmp.get_nvts(
+            extended=True, preferences_config_id="preferences_config_id"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_nvts preferences_config_id="preferences_config_id"/>'
+        )
+
+    def test_get_extended_nvts_with_family(self):
+        self.gmp.get_nvts(extended=True, family="family")
+
+        self.connection.send.has_been_called_with('<get_nvts family="family"/>')
+
+    def test_get_extended_nvts_with_sort_order(self):
+        self.gmp.get_nvts(extended=True, sort_order="sort_order")
+
+        self.connection.send.has_been_called_with(
+            '<get_nvts sort_order="sort_order"/>'
+        )
+
+    def test_get_extended_nvts_with_sort_field(self):
+        self.gmp.get_nvts(extended=True, sort_field="sort_field")
+
+        self.connection.send.has_been_called_with(
+            '<get_nvts sort_field="sort_field"/>'
         )


### PR DESCRIPTION
## What

* Add the calls to `get_nvts` and `get_nvt` back
* The previous implementation calls `get_info`, which doesn't return the same results like `get_nvts`
* To use the `get_nvts` call, set `extended=True` in the `get_nvt` and `get_nvts` calls

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why


* Required functionality
<!-- Describe why are these changes necessary? -->

## References
GEA-168
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


