### PR TITLE
Fix: Set permissions for conventional commits workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -3,6 +3,10 @@ name: Conventional Commits
 on:
   pull_request:
 
+permissions:
+  pull-requests: write
+  contents: read
+
 jobs:
   conventional-commits:
     name: Conventional Commits


### PR DESCRIPTION

## What

Set permissions for conventional commits workflow

## Why
The conventional commits workflows requires write permissions for creating PR comments and read permissions to the repo contents.