### PR TITLE
Change: Set TLS minimum version, avoid version protocols

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -494,8 +494,13 @@ class TLSConnection(GvmConnection):
                 keyfile=self.keyfile,
                 password=self.password,
             )
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
         else:
-            context = ssl.SSLContext(ssl.PROTOCOL_TLSv1_2)
+            context = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            context.minimum_version = ssl.TLSVersion.TLSv1_2
+            context.check_hostname = False
+            context.verify_mode = ssl.CERT_NONE
+
         sock = context.wrap_socket(transport_socket, server_side=False)
 
         sock.settimeout(self._timeout)


### PR DESCRIPTION
## What
TLS connections now require TLS 1.2 as the minimum version whether certificate files are given or not.
Also, the deprecated version specific protocol for TLS 1.2 is no longer used.

## Why
This changes prevents possible security issues from allowing connections with older, less secure TLS versions.


