### PR TITLE
Change: Create conventional commits for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,17 +1,20 @@
 version: 2
 updates:
+  - package-ecosystem: pip
+    directory: "/"
+    schedule:
+      interval: weekly
+      time: "04:00"
+    open-pull-requests-limit: 10
+    allow:
+      - dependency-type: direct
+      - dependency-type: indirect
+    commit-message:
+      prefix: "Deps"
 
-- package-ecosystem: pip
-  directory: "/"
-  schedule:
-    interval: "weekly"
-    time: "04:00"
-  open-pull-requests-limit: 10
-  allow:
-  - dependency-type: direct
-  - dependency-type: indirect
-
-- package-ecosystem: "github-actions"
-  directory: "/"
-  schedule:
-    interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "Deps"


### PR DESCRIPTION


## What

Create conventional commits for dependabot

## Why

Change dependabot config to create convention commit messages. This allows to include dependency updates in the release changelogs.