### PR TITLE
fix(protocols/base): do not disconnect on TimeoutError

### DIFF
--- a/gvm/protocols/base.py
+++ b/gvm/protocols/base.py
@@ -135,6 +135,8 @@ class GvmProtocol:
         try:
             self._send(cmd)
             response = self._read()
+        except TimeoutError as e:
+            raise e
         except Exception as e:
             self.disconnect()
             raise e


### PR DESCRIPTION
## What

This edit makes send_command avoid disconnecting on `TimeoutError`, so the command can be retried by the caller.

## Why

GVM commands may lead `TimeoutError` as the daemon is using a lot of resources.