### PR TITLE
Add: New GMP version 22.05

### DIFF
--- a/gvm/protocols/gmp.py
+++ b/gvm/protocols/gmp.py
@@ -27,11 +27,12 @@ from gvm.protocols.base import GvmConnection, GvmProtocol
 from gvm.protocols.gmpv208 import Gmp as Gmpv208
 from gvm.protocols.gmpv214 import Gmp as Gmpv214
 from gvm.protocols.gmpv224 import Gmp as Gmpv224
+from gvm.protocols.gmpv225 import Gmp as Gmpv225
 from gvm.transforms import EtreeCheckCommandTransform
 from gvm.xml import XmlCommand
 
 SUPPORTED_GMP_VERSIONS = Union[  # pylint: disable=invalid-name
-    Gmpv208, Gmpv214, Gmpv224
+    Gmpv208, Gmpv214, Gmpv224, Gmpv225
 ]
 
 
@@ -104,6 +105,8 @@ class Gmp(GvmProtocol):
             gmp_class = Gmpv214
         elif major_version == 22 and minor_version == 4:
             gmp_class = Gmpv224
+        elif major_version == 22 and minor_version == 5:
+            gmp_class = Gmpv225
         else:
             raise GvmError(
                 "Remote manager daemon uses an unsupported version of GMP. "

--- a/gvm/protocols/gmpv225/__init__.py
+++ b/gvm/protocols/gmpv225/__init__.py
@@ -1,0 +1,210 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=too-many-lines,redefined-builtin
+
+"""
+Module for communication with gvmd in
+`Greenbone Management Protocol version 22.05`_
+
+.. _Greenbone Management Protocol version 22.05:
+    https://docs.greenbone.net/API/GMP/gmp-22.05.html
+"""
+
+import logging
+from typing import Any, Callable, Optional
+
+from gvm.connections import GvmConnection
+from gvm.protocols.base import GvmProtocol
+from gvm.protocols.gmpv208.entities.alerts import (
+    AlertCondition,
+    AlertEvent,
+    AlertMethod,
+    AlertsMixin,
+)
+from gvm.protocols.gmpv208.entities.audits import AuditsMixin
+from gvm.protocols.gmpv208.entities.credentials import (
+    CredentialFormat,
+    CredentialsMixin,
+    CredentialType,
+    SnmpAuthAlgorithm,
+    SnmpPrivacyAlgorithm,
+)
+from gvm.protocols.gmpv208.entities.entities import EntityType
+from gvm.protocols.gmpv208.entities.filter import FiltersMixin, FilterType
+from gvm.protocols.gmpv208.entities.groups import GroupsMixin
+from gvm.protocols.gmpv208.entities.hosts import HostsMixin, HostsOrdering
+from gvm.protocols.gmpv208.entities.operating_systems import (
+    OperatingSystemsMixin,
+)
+from gvm.protocols.gmpv208.entities.permissions import (
+    PermissionsMixin,
+    PermissionSubjectType,
+)
+from gvm.protocols.gmpv208.entities.policies import PoliciesMixin
+from gvm.protocols.gmpv208.entities.port_lists import (
+    PortListMixin,
+    PortRangeType,
+)
+from gvm.protocols.gmpv208.entities.report_formats import (
+    ReportFormatsMixin,
+    ReportFormatType,
+)
+from gvm.protocols.gmpv208.entities.reports import ReportsMixin
+from gvm.protocols.gmpv208.entities.results import ResultsMixin
+from gvm.protocols.gmpv208.entities.roles import RolesMixin
+from gvm.protocols.gmpv208.entities.schedules import SchedulesMixin
+from gvm.protocols.gmpv208.entities.secinfo import InfoType, SecInfoMixin
+from gvm.protocols.gmpv208.entities.severity import SeverityLevel
+from gvm.protocols.gmpv208.entities.tags import TagsMixin
+from gvm.protocols.gmpv208.entities.tasks import TasksMixin
+from gvm.protocols.gmpv208.entities.tickets import TicketsMixin, TicketStatus
+from gvm.protocols.gmpv208.entities.tls_certificates import TLSCertificateMixin
+from gvm.protocols.gmpv208.entities.users import UserAuthType
+from gvm.protocols.gmpv208.entities.vulnerabilities import VulnerabilitiesMixin
+from gvm.protocols.gmpv208.system.aggregates import (
+    AggregatesMixin,
+    AggregateStatistic,
+    SortOrder,
+)
+from gvm.protocols.gmpv208.system.authentication import AuthenticationMixin
+from gvm.protocols.gmpv208.system.feed import FeedMixin, FeedType
+from gvm.protocols.gmpv208.system.help import HelpFormat, HelpMixin
+from gvm.protocols.gmpv208.system.system_reports import SystemReportsMixin
+from gvm.protocols.gmpv208.system.trashcan import TrashcanMixin
+from gvm.protocols.gmpv208.system.user_settings import UserSettingsMixin
+
+# NEW IN 214
+from gvm.protocols.gmpv214.entities.notes import NotesMixin
+from gvm.protocols.gmpv214.entities.overrides import OverridesMixin
+from gvm.protocols.gmpv214.entities.targets import AliveTest, TargetsMixin
+from gvm.protocols.gmpv224.entities.scan_configs import ScanConfigsMixin
+from gvm.protocols.gmpv224.entities.scanners import ScannersMixin, ScannerType
+
+# NEW IN 224
+from gvm.protocols.gmpv224.entities.users import UsersMixin
+
+# NEW IN 225
+from gvm.protocols.gmpv225.entities.resourcenames import (
+    ResourceNamesMixin,
+    ResourceType,
+)
+from gvm.protocols.gmpv225.system.version import VersionMixin
+from gvm.utils import to_dotted_types_dict
+
+logger = logging.getLogger(__name__)
+
+_TYPE_FIELDS = [
+    AggregateStatistic,
+    AlertCondition,
+    AlertEvent,
+    AlertMethod,
+    AliveTest,
+    CredentialFormat,
+    CredentialType,
+    EntityType,
+    FeedType,
+    FilterType,
+    HostsOrdering,
+    InfoType,
+    HelpFormat,
+    PortRangeType,
+    PermissionSubjectType,
+    ReportFormatType,
+    ResourceType,
+    ScannerType,
+    SeverityLevel,
+    SnmpAuthAlgorithm,
+    SnmpPrivacyAlgorithm,
+    SortOrder,
+    TicketStatus,
+    UserAuthType,
+]
+
+
+class Gmp(
+    GvmProtocol,
+    AggregatesMixin,
+    AlertsMixin,
+    AuditsMixin,
+    AuthenticationMixin,
+    CredentialsMixin,
+    FeedMixin,
+    FiltersMixin,
+    GroupsMixin,
+    HelpMixin,
+    HostsMixin,
+    NotesMixin,
+    OperatingSystemsMixin,
+    OverridesMixin,
+    PermissionsMixin,
+    PoliciesMixin,
+    PortListMixin,
+    ReportFormatsMixin,
+    ReportsMixin,
+    ResourceNamesMixin,
+    ResultsMixin,
+    RolesMixin,
+    TagsMixin,
+    TargetsMixin,
+    TasksMixin,
+    TicketsMixin,
+    TLSCertificateMixin,
+    TrashcanMixin,
+    ScanConfigsMixin,
+    ScannersMixin,
+    SchedulesMixin,
+    SecInfoMixin,
+    SystemReportsMixin,
+    UserSettingsMixin,
+    UsersMixin,
+    VersionMixin,
+    VulnerabilitiesMixin,
+):
+    """Python interface for Greenbone Management Protocol
+
+    This class implements the `Greenbone Management Protocol version 22.05`_
+
+    Arguments:
+        connection: Connection to use to talk with the gvmd daemon. See
+            :mod:`gvm.connections` for possible connection types.
+        transform: Optional transform `callable`_ to convert response data.
+            After each request the callable gets passed the plain response data
+            which can be used to check the data and/or conversion into different
+            representations like a xml dom.
+
+            See :mod:`gvm.transforms` for existing transforms.
+
+    .. _Greenbone Management Protocol version 22.05:
+        https://docs.greenbone.net/API/GMP/gmp-22.05.html
+    .. _callable:
+        https://docs.python.org/3/library/functions.html#callable
+    """
+
+    def __init__(
+        self,
+        connection: GvmConnection,
+        *,
+        transform: Optional[Callable[[str], Any]] = None,
+    ):
+        self.types = to_dotted_types_dict(_TYPE_FIELDS)
+
+        super().__init__(connection, transform=transform)
+
+        # Is authenticated on gvmd
+        self._authenticated = False

--- a/gvm/protocols/gmpv225/entities/__init__.py
+++ b/gvm/protocols/gmpv225/entities/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -15,21 +15,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
-Package for supported Greenbone Protocol versions.
-
-Currently `GMP version 20.08`_, `GMP version 21.04`_
-`GMP version 22.04`, `GMP version 22.05`
-and `OSP version 1`_ are supported.
-
-.. _GMP version 20.08:
-    https://docs.greenbone.net/API/GMP/gmp-20.08.html
-.. _GMP version 21.04:
-    https://docs.greenbone.net/API/GMP/gmp-21.04.html
-.. _GMP version 22.04:
-    https://docs.greenbone.net/API/GMP/gmp-22.04.html
-.. _GMP version 22.05:
-    https://docs.greenbone.net/API/GMP/gmp-22.05.html    
-.. _OSP version 1:
-    https://docs.greenbone.net/API/OSP/osp-1.2.html
-"""

--- a/gvm/protocols/gmpv225/entities/resourcenames.py
+++ b/gvm/protocols/gmpv225/entities/resourcenames.py
@@ -1,0 +1,159 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from enum import Enum
+from typing import Any, Optional
+
+from gvm.errors import InvalidArgument, InvalidArgumentType, RequiredArgument
+from gvm.utils import add_filter
+from gvm.xml import XmlCommand
+
+
+class ResourceType(Enum):
+    """Enum for resource types"""
+
+    ALERT = "ALERT"
+    CERT_BUND_ADV = "CERT_BUND_ADV"
+    CONFIG = "CONFIG"
+    CPE = "CPE"
+    CREDENTIAL = "CREDENTIAL"
+    CVE = "CVE"
+    DFN_CERT_ADV = "DFN_CERT_ADV"
+    FILTER = "FILTER"
+    GROUP = "GROUP"
+    HOST = "HOST"
+    NOTE = "NOTE"
+    NVT = "NVT"
+    OS = "OS"
+    OVERRIDE = "OVERRIDE"
+    PERMISSION = "PERMISSION"
+    PORT_LIST = "PORT_LIST"
+    REPORT_FORMAT = "REPORT_FORMAT"
+    REPORT = "REPORT"
+    RESULT = "RESULT"
+    ROLE = "ROLE"
+    SCANNER = "SCANNER"
+    SCHEDULE = "SCHEDULE"
+    TARGET = "TARGET"
+    TASK = "TASK"
+    TLS_CERTIFICATE = "TLS_CERTIFICATE"
+    USER = "USER"
+
+    @classmethod
+    def from_string(
+        cls,
+        resource_type: Optional[str],
+    ) -> Optional["ResourceType"]:
+        """Convert a resource type string to an actual ResourceType instance
+
+        Arguments:
+            resource_type: Resource type string to convert to a ResourceType
+        """
+        if not resource_type:
+            return None
+        try:
+            return cls[resource_type.upper()]
+        except KeyError:
+            raise InvalidArgument(
+                argument="resource_type", function=cls.from_string.__name__
+            ) from None
+
+
+class ResourceNamesMixin:
+    def get_resource_names_list(
+        self,
+        resource_type: ResourceType,
+        filter_string: Optional[str] = None,
+    ) -> Any:
+        """Request a list of resource names and IDs
+
+        Arguments:
+            resource_type: Type must be either ALERT, CERT_BUND_ADV,
+            CONFIG, CPE, CREDENTIAL, CVE, DFN_CERT_ADV, FILTER,
+            GROUP, HOST, NOTE, NVT, OS, OVERRIDE, PERMISSION,
+            PORT_LIST, REPORT_FORMAT, REPORT, RESULT, ROLE,
+            SCANNER, SCHEDULE, TARGET, TASK, TLS_CERTIFICATE
+            or USER
+            filter_string: Filter term to use for the query
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not resource_type:
+            raise RequiredArgument(
+                function=self.get_resource_names_list.__name__,
+                argument="resource_type",
+            )
+
+        if not isinstance(resource_type, ResourceType):
+            raise InvalidArgumentType(
+                function=self.get_resource_names_list.__name__,
+                argument="resource_type",
+                arg_type=ResourceType.__name__,
+            )
+
+        cmd = XmlCommand("get_resource_names")
+
+        cmd.set_attribute("type", resource_type.value)
+
+        add_filter(cmd, filter_string, None)
+
+        return self._send_xml_command(cmd)
+
+    def get_resource_name(
+        self, resource_id: str, resource_type: ResourceType
+    ) -> Any:
+        """Request a single resource name
+
+        Arguments:
+            resource_id: ID of an existing resource
+            resource_type: Type must be either ALERT, CERT_BUND_ADV,
+            CONFIG, CPE, CREDENTIAL, CVE, DFN_CERT_ADV, FILTER,
+            GROUP, HOST, NOTE, NVT, OS, OVERRIDE, PERMISSION,
+            PORT_LIST, REPORT_FORMAT, REPORT, RESULT, ROLE,
+            SCANNER, SCHEDULE, TARGET, TASK, TLS_CERTIFICATE
+            or USER
+
+        Returns:
+            The response. See :py:meth:`send_command` for details.
+        """
+        if not resource_type:
+            raise RequiredArgument(
+                function=self.get_resource_name.__name__,
+                argument="resource_type",
+            )
+
+        if not isinstance(resource_type, ResourceType):
+            raise InvalidArgumentType(
+                function=self.get_resource_name.__name__,
+                argument="resource_type",
+                arg_type=ResourceType.__name__,
+            )
+
+        if not resource_id:
+            raise RequiredArgument(
+                function=self.get_resource_name.__name__, argument="resource_id"
+            )
+
+        cmd = XmlCommand("get_resource_names")
+        cmd.set_attribute("resource_id", resource_id)
+
+        cmd.set_attribute("type", resource_type.value)
+
+        return self._send_xml_command(cmd)

--- a/gvm/protocols/gmpv225/system/__init__.py
+++ b/gvm/protocols/gmpv225/system/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -15,21 +15,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
-Package for supported Greenbone Protocol versions.
-
-Currently `GMP version 20.08`_, `GMP version 21.04`_
-`GMP version 22.04`, `GMP version 22.05`
-and `OSP version 1`_ are supported.
-
-.. _GMP version 20.08:
-    https://docs.greenbone.net/API/GMP/gmp-20.08.html
-.. _GMP version 21.04:
-    https://docs.greenbone.net/API/GMP/gmp-21.04.html
-.. _GMP version 22.04:
-    https://docs.greenbone.net/API/GMP/gmp-22.04.html
-.. _GMP version 22.05:
-    https://docs.greenbone.net/API/GMP/gmp-22.05.html    
-.. _OSP version 1:
-    https://docs.greenbone.net/API/OSP/osp-1.2.html
-"""

--- a/gvm/protocols/gmpv225/system/version.py
+++ b/gvm/protocols/gmpv225/system/version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -15,21 +15,22 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-"""
-Package for supported Greenbone Protocol versions.
 
-Currently `GMP version 20.08`_, `GMP version 21.04`_
-`GMP version 22.04`, `GMP version 22.05`
-and `OSP version 1`_ are supported.
 
-.. _GMP version 20.08:
-    https://docs.greenbone.net/API/GMP/gmp-20.08.html
-.. _GMP version 21.04:
-    https://docs.greenbone.net/API/GMP/gmp-21.04.html
-.. _GMP version 22.04:
-    https://docs.greenbone.net/API/GMP/gmp-22.04.html
-.. _GMP version 22.05:
-    https://docs.greenbone.net/API/GMP/gmp-22.05.html    
-.. _OSP version 1:
-    https://docs.greenbone.net/API/OSP/osp-1.2.html
-"""
+from gvm.protocols.gmpv208.system.version import (
+    VersionMixin as Gmp208VersionMixin,
+)
+
+PROTOCOL_VERSION = (22, 5)
+
+
+class VersionMixin(Gmp208VersionMixin):
+    @staticmethod
+    def get_protocol_version() -> tuple:
+        """Determine the Greenbone Management Protocol (gmp) version used
+        by python-gvm version.
+
+        Returns:
+            tuple: Implemented version of the Greenbone Management Protocol
+        """
+        return PROTOCOL_VERSION

--- a/gvm/protocols/latest.py
+++ b/gvm/protocols/latest.py
@@ -34,7 +34,7 @@ Exports:
     https://docs.greenbone.net/API/GMP/gmp.html
 """
 
-from .gmpv224 import (
+from .gmpv225 import (
     AggregateStatistic,
     AlertCondition,
     AlertEvent,
@@ -52,6 +52,7 @@ from .gmpv224 import (
     PermissionSubjectType,
     PortRangeType,
     ReportFormatType,
+    ResourceType,
     ScannerType,
     SeverityLevel,
     SnmpAuthAlgorithm,
@@ -81,6 +82,7 @@ __all__ = [
     "PermissionSubjectType",
     "PortRangeType",
     "ReportFormatType",
+    "ResourceType",
     "ScannerType",
     "SeverityLevel",
     "SnmpAuthAlgorithm",

--- a/gvm/protocols/next.py
+++ b/gvm/protocols/next.py
@@ -27,14 +27,14 @@ For details about the possible supported protocol versions please take a look at
 :py:mod:`gvm.protocols`.
 
 Exports:
-  - :py:class:`gvm.protocols.gmpv224.Gmp`
+  - :py:class:`gvm.protocols.gmpv225.Gmp`
   - :py:class:`gvm.protocols.ospv1.Osp`
 
 .. _Greenbone Management Protocol:
     https://docs.greenbone.net/API/GMP/gmp.html
 """
 
-from .gmpv224 import (
+from .gmpv225 import (
     AggregateStatistic,
     AlertCondition,
     AlertEvent,
@@ -52,6 +52,7 @@ from .gmpv224 import (
     PermissionSubjectType,
     PortRangeType,
     ReportFormatType,
+    ResourceType,
     ScannerType,
     SeverityLevel,
     SnmpAuthAlgorithm,
@@ -81,6 +82,7 @@ __all__ = [
     "PermissionSubjectType",
     "PortRangeType",
     "ReportFormatType",
+    "ResourceType",
     "ScannerType",
     "SeverityLevel",
     "SnmpAuthAlgorithm",

--- a/tests/protocols/gmp/test_context_manager.py
+++ b/tests/protocols/gmp/test_context_manager.py
@@ -23,6 +23,8 @@ from gvm.errors import GvmError
 from gvm.protocols.gmp import Gmp
 from gvm.protocols.gmpv208 import Gmp as Gmpv208
 from gvm.protocols.gmpv214 import Gmp as Gmpv214
+from gvm.protocols.gmpv224 import Gmp as Gmpv224
+from gvm.protocols.gmpv225 import Gmp as Gmpv225
 from tests.protocols import GmpTestCase
 
 
@@ -83,6 +85,28 @@ class GmpContextManagerTestCase(GmpTestCase):
         with self.gmp as gmp:
             self.assertEqual(gmp.get_protocol_version(), (21, 4))
             self.assertIsInstance(gmp, Gmpv214)
+
+    def test_select_gmpv224(self):
+        self.connection.read.return_value(
+            '<get_version_response status="200" status_text="OK">'
+            "<version>22.04</version>"
+            "</get_version_response>"
+        )
+
+        with self.gmp as gmp:
+            self.assertEqual(gmp.get_protocol_version(), (22, 4))
+            self.assertIsInstance(gmp, Gmpv224)
+
+    def test_select_gmpv225(self):
+        self.connection.read.return_value(
+            '<get_version_response status="200" status_text="OK">'
+            "<version>22.05</version>"
+            "</get_version_response>"
+        )
+
+        with self.gmp as gmp:
+            self.assertEqual(gmp.get_protocol_version(), (22, 5))
+            self.assertIsInstance(gmp, Gmpv225)
 
     def test_unknown_protocol(self):
         self.connection.read.return_value(

--- a/tests/protocols/gmpv225/__init__.py
+++ b/tests/protocols/gmpv225/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
 
-import unittest
+from gvm.protocols.gmpv225 import Gmp
 
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from .. import GmpTestCase
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225TestCase(GmpTestCase):
+    gmp_class = Gmp

--- a/tests/protocols/gmpv225/entities/__init__.py
+++ b/tests/protocols/gmpv225/entities/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -15,21 +15,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/protocols/gmpv225/entities/resourcenames/__init__.py
+++ b/tests/protocols/gmpv225/entities/resourcenames/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
-
-
-if __name__ == "__main__":
-    unittest.main()
+from .test_get_resource_name import GmpGetResourceNameTestMixin
+from .test_get_resource_names_list import GmpGetResourceNamesListTestMixin

--- a/tests/protocols/gmpv225/entities/resourcenames/test_get_resource_name.py
+++ b/tests/protocols/gmpv225/entities/resourcenames/test_get_resource_name.py
@@ -1,0 +1,251 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import InvalidArgumentType, RequiredArgument
+from gvm.protocols.gmpv225 import ResourceType
+
+
+class GmpGetResourceNameTestMixin:
+    def test_get_resource_name(self):
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.ALERT, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="ALERT"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.CERT_BUND_ADV, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="CERT_BUND_ADV"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.CONFIG, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="CONFIG"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.CPE, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="CPE"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.CREDENTIAL, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="CREDENTIAL"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.CVE, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="CVE"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.DFN_CERT_ADV, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="DFN_CERT_ADV"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.FILTER, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="FILTER"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.GROUP, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="GROUP"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.HOST, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="HOST"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.NOTE, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="NOTE"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.NVT, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="NVT"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.OS, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="OS"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.PERMISSION, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="PERMISSION"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.PORT_LIST, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="PORT_LIST"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.REPORT_FORMAT, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="REPORT_FORMAT"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.REPORT, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="REPORT"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.RESULT, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="RESULT"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.ROLE, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="ROLE"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.SCANNER, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="SCANNER"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.SCHEDULE, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="SCHEDULE"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.TARGET, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="TARGET"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.TASK, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="TASK"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.TLS_CERTIFICATE, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="TLS_CERTIFICATE"/>'
+        )
+
+        self.gmp.get_resource_name(
+            resource_type=ResourceType.USER, resource_id="i1"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names resource_id="i1" type="USER"/>'
+        )
+
+    def test_get_resource_name_missing_resource_type(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_resource_name(resource_id="i1", resource_type=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_resource_name(resource_id="i1", resource_type="")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_resource_name("i1", "")
+
+    def test_get_resource_name_invalid_resource_type(self):
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.get_resource_name(resource_id="i1", resource_type="foo")
+
+    def test_get_resource_name_missing_resource_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_resource_name(
+                resource_id="", resource_type=ResourceType.CPE
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_resource_name("", resource_type=ResourceType.CPE)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_resource_name(
+                resource_id=None, resource_type=ResourceType.CPE
+            )

--- a/tests/protocols/gmpv225/entities/resourcenames/test_get_resource_names_list.py
+++ b/tests/protocols/gmpv225/entities/resourcenames/test_get_resource_names_list.py
@@ -1,0 +1,207 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.errors import InvalidArgumentType, RequiredArgument
+from gvm.protocols.gmpv225 import ResourceType
+
+
+class GmpGetResourceNamesListTestMixin:
+    def test_get_resource_names_list(self):
+        self.gmp.get_resource_names_list(ResourceType.ALERT)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="ALERT"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.CERT_BUND_ADV)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="CERT_BUND_ADV"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.CONFIG)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="CONFIG"/>'
+        )
+
+        self.gmp.get_resource_names_list(resource_type=ResourceType.CPE)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="CPE"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.CREDENTIAL)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="CREDENTIAL"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.CVE)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="CVE"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.DFN_CERT_ADV)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="DFN_CERT_ADV"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.FILTER)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="FILTER"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.GROUP)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="GROUP"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.HOST)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="HOST"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.NOTE)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="NOTE"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.NVT)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="NVT"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.OS)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="OS"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.OVERRIDE)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="OVERRIDE"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.PERMISSION)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="PERMISSION"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.PORT_LIST)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="PORT_LIST"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.REPORT_FORMAT)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="REPORT_FORMAT"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.REPORT)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="REPORT"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.RESULT)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="RESULT"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.ROLE)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="ROLE"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.SCANNER)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="SCANNER"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.SCHEDULE)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="SCHEDULE"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.TARGET)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="TARGET"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.TASK)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="TASK"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.TLS_CERTIFICATE)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="TLS_CERTIFICATE"/>'
+        )
+
+        self.gmp.get_resource_names_list(ResourceType.USER)
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="USER"/>'
+        )
+
+        with self.assertRaises(AttributeError):
+            self.gmp.get_resource_names_list(
+                ResourceType.ALLRESOURCES  # pylint: disable=no-member
+            )
+
+    def test_get_resource_names_list_missing_resource_type(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_resource_names_list(resource_type=None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_resource_names_list(resource_type="")
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_resource_names_list("")
+
+    def test_get_resource_names_list_invalid_resource_type(self):
+        with self.assertRaises(InvalidArgumentType):
+            self.gmp.get_resource_names_list(resource_type="foo")
+
+    def test_get_resource_names_list_with_filter_string(self):
+        self.gmp.get_resource_names_list(
+            ResourceType.CPE, filter_string="foo=bar"
+        )
+
+        self.connection.send.has_been_called_with(
+            '<get_resource_names type="CPE" filter="foo=bar"/>'
+        )

--- a/tests/protocols/gmpv225/entities/test_alerts.py
+++ b/tests/protocols/gmpv225/entities/test_alerts.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.alerts import (
+    GmpCloneAlertTestMixin,
+    GmpCreateAlertTestMixin,
+    GmpDeleteAlertTestMixin,
+    GmpGetAlertsTestMixin,
+    GmpGetAlertTestMixin,
+    GmpModifyAlertTestMixin,
+    GmpTestAlertTestMixin,
+    GmpTriggerAlertTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225CloneAlertTestCase(GmpCloneAlertTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateAlertTestCase(GmpCreateAlertTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225DeleteAlertTestCase(GmpDeleteAlertTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetAlertTestCase(GmpGetAlertTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetAlertsTestCase(GmpGetAlertsTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyAlertTestCase(GmpModifyAlertTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225TestAlertTestCase(GmpTestAlertTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225TriggerAlertTestCase(GmpTriggerAlertTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_audits.py
+++ b/tests/protocols/gmpv225/entities/test_audits.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.audits import (
+    GmpCloneAuditTestMixin,
+    GmpCreateAuditTestMixin,
+    GmpDeleteAuditTestMixin,
+    GmpGetAuditsTestMixin,
+    GmpGetAuditTestMixin,
+    GmpModifyAuditTestMixin,
+    GmpResumeAuditTestMixin,
+    GmpStartAuditTestMixin,
+    GmpStopAuditTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225CloneAuditTestCase(GmpCloneAuditTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateAuditTestCase(GmpCreateAuditTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225DeleteAuditTestCase(GmpDeleteAuditTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetAuditTestCase(GmpGetAuditTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetAuditsTestCase(GmpGetAuditsTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyAuditTestCase(GmpModifyAuditTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ResumeAuditTestCase(GmpResumeAuditTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225StartAuditTestCase(GmpStartAuditTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225StopAuditTestCase(GmpStopAuditTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_credentials.py
+++ b/tests/protocols/gmpv225/entities/test_credentials.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.credentials import (
+    GmpCloneCredentialTestMixin,
+    GmpCreateCredentialTestMixin,
+    GmpDeleteCredentialTestMixin,
+    GmpGetCredentialsTestMixin,
+    GmpGetCredentialTestMixin,
+    GmpModifyCredentialTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225CloneCredentialTestCase(
+    GmpCloneCredentialTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225CreateCredentialTestCase(
+    GmpCreateCredentialTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225DeleteCredentialTestCase(
+    GmpDeleteCredentialTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetCredentialTestCase(GmpGetCredentialTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetCredentialsTestCase(
+    GmpGetCredentialsTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyCredentialTestCase(
+    GmpModifyCredentialTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_filters.py
+++ b/tests/protocols/gmpv225/entities/test_filters.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.filters import (
+    GmpCloneFilterTestMixin,
+    GmpCreateFilterTestMixin,
+    GmpDeleteFilterTestMixin,
+    GmpGetFiltersTestMixin,
+    GmpGetFilterTestMixin,
+    GmpModifyFilterTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeleteFilterTestCase(GmpDeleteFilterTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetFilterTestCase(GmpGetFilterTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetFiltersTestCase(GmpGetFiltersTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CloneFilterTestCase(GmpCloneFilterTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateFilterTestCase(GmpCreateFilterTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyFilterTestCase(GmpModifyFilterTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_groups.py
+++ b/tests/protocols/gmpv225/entities/test_groups.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.groups import (
+    GmpCloneGroupTestMixin,
+    GmpCreateGroupTestMixin,
+    GmpDeleteGroupTestMixin,
+    GmpGetGroupsTestMixin,
+    GmpGetGroupTestMixin,
+    GmpModifyGroupTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeleteGroupTestCase(GmpDeleteGroupTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetGroupTestCase(GmpGetGroupTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetGroupsTestCase(GmpGetGroupsTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CloneGroupTestCase(GmpCloneGroupTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateGroupTestCase(GmpCreateGroupTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyGroupTestCase(GmpModifyGroupTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_hosts.py
+++ b/tests/protocols/gmpv225/entities/test_hosts.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,31 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from ...gmpv208.entities.hosts import (
+    GmpCreateHostTestMixin,
+    GmpDeleteHostTestMixin,
+    GmpGetHostsTestMixin,
+    GmpGetHostTestMixin,
+    GmpModifyHostTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225CreateHostTestCase(GmpCreateHostTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225DeleteHostTestCase(GmpDeleteHostTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetHostTestCase(GmpGetHostTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetHostsTestCase(GmpGetHostsTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyHostTestCase(GmpModifyHostTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_notes.py
+++ b/tests/protocols/gmpv225/entities/test_notes.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.notes import (
+    GmpCloneNoteTestMixin,
+    GmpDeleteNoteTestMixin,
+    GmpGetNotesTestMixin,
+    GmpGetNoteTestMixin,
+)
+from ...gmpv224.entities.notes import (
+    GmpCreateNoteTestMixin,
+    GmpModifyNoteTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeleteNoteTestCase(GmpDeleteNoteTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetNoteTestCase(GmpGetNoteTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetNotesTestCase(GmpGetNotesTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CloneNoteTestCase(GmpCloneNoteTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateNoteTestCase(GmpCreateNoteTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyNoteTestCase(GmpModifyNoteTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_operating_systems.py
+++ b/tests/protocols/gmpv225/entities/test_operating_systems.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,34 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from ...gmpv208.entities.operating_systems import (
+    GmpDeleteOperatingSystemTestMixin,
+    GmpGetOperatingSystemsTestMixin,
+    GmpGetOperatingSystemTestMixin,
+    GmpModifyOperatingSystemTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225DeleteOperatingSystemTestCase(
+    GmpDeleteOperatingSystemTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetOperatingSystemTestCase(
+    GmpGetOperatingSystemTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetOperatingSystemsTestCase(
+    GmpGetOperatingSystemsTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyOperatingSystemTestCase(
+    GmpModifyOperatingSystemTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_overrides.py
+++ b/tests/protocols/gmpv225/entities/test_overrides.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.overrides import (
+    GmpCloneOverrideTestMixin,
+    GmpDeleteOverrideTestMixin,
+    GmpGetOverridesTestMixin,
+    GmpGetOverrideTestMixin,
+)
+from ...gmpv224.entities.overrides import (
+    GmpCreateOverrideTestMixin,
+    GmpModifyOverrideTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225CloneOverrideTestCase(GmpCloneOverrideTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateOverrideTestCase(
+    GmpCreateOverrideTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225DeleteOverrideTestCase(
+    GmpDeleteOverrideTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetOverrideTestCase(GmpGetOverrideTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetOverridesTestCase(GmpGetOverridesTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyOverrideTestCase(
+    GmpModifyOverrideTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_permissions.py
+++ b/tests/protocols/gmpv225/entities/test_permissions.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.permissions import (
+    GmpClonePermissionTestMixin,
+    GmpCreatePermissionTestMixin,
+    GmpDeletePermissionTestMixin,
+    GmpGetPermissionsTestMixin,
+    GmpGetPermissionTestMixin,
+    GmpModifyPermissionTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeletePermissionTestCase(
+    GmpDeletePermissionTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetPermissionTestCase(GmpGetPermissionTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetPermissionsTestCase(
+    GmpGetPermissionsTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ClonePermissionTestCase(
+    GmpClonePermissionTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225CreatePermissionTestCase(
+    GmpCreatePermissionTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyPermissionTestCase(
+    GmpModifyPermissionTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_policies.py
+++ b/tests/protocols/gmpv225/entities/test_policies.py
@@ -1,0 +1,93 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.policies import (
+    GmpClonePolicyTestMixin,
+    GmpCreatePolicyTestMixin,
+    GmpDeletePolicyTestMixin,
+    GmpGetPoliciesTestMixin,
+    GmpGetPolicyTestMixin,
+    GmpImportPolicyTestMixin,
+    GmpModifyPolicySetCommentTestMixin,
+    GmpModifyPolicySetFamilySelectionTestMixin,
+    GmpModifyPolicySetNameTestMixin,
+    GmpModifyPolicySetNvtPreferenceTestMixin,
+    GmpModifyPolicySetNvtSelectionTestMixin,
+    GmpModifyPolicySetScannerPreferenceTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225ClonePolicyTestCase(GmpClonePolicyTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreatePolicyTestCase(GmpCreatePolicyTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225DeletePolicyTestCase(GmpDeletePolicyTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetPolicyTestCase(GmpGetPolicyTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetPoliciesTestCase(GmpGetPoliciesTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ImportPolicyTestCase(GmpImportPolicyTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyPolicySetCommentTestCase(
+    GmpModifyPolicySetCommentTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyPolicySetFamilySelectionTestCase(
+    GmpModifyPolicySetFamilySelectionTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyPolicySetNvtSelectionTestCase(
+    GmpModifyPolicySetNvtSelectionTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyPolicySetNameTestCase(
+    GmpModifyPolicySetNameTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyPolicySetNvtPreferenceTestCase(
+    GmpModifyPolicySetNvtPreferenceTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyPolicySetScannerPreferenceTestCase(
+    GmpModifyPolicySetScannerPreferenceTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_port_lists.py
+++ b/tests/protocols/gmpv225/entities/test_port_lists.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.port_lists import (
+    GmpClonePortListTestMixin,
+    GmpCreatePortListTestMixin,
+    GmpCreatePortRangeTestMixin,
+    GmpDeletePortListTestMixin,
+    GmpDeletePortRangeTestMixin,
+    GmpGetPortListsTestMixin,
+    GmpGetPortListTestMixin,
+    GmpModifyPortListTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225ClonePortListTestCase(GmpClonePortListTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreatePortListTestCase(
+    GmpCreatePortListTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225CreatePortRangeListTestCase(
+    GmpCreatePortRangeTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225DeletePortListTestCase(
+    GmpDeletePortListTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225DeletePortRangeTestCase(
+    GmpDeletePortRangeTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetPortListTestCase(GmpGetPortListTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetPortListsTestCase(GmpGetPortListsTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyPortListTestCase(
+    GmpModifyPortListTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_report_formats.py
+++ b/tests/protocols/gmpv225/entities/test_report_formats.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.report_formats import (
+    GmpCloneReportFormatTestMixin,
+    GmpDeleteReportFormatTestMixin,
+    GmpGetReportFormatsTestMixin,
+    GmpGetReportFormatTestMixin,
+    GmpImportReportFormatTestMixin,
+    GmpModifyReportFormatTestMixin,
+    GmpVerifyReportFormatTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeleteReportFormatTestCase(
+    GmpDeleteReportFormatTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetReportFormatTestCase(
+    GmpGetReportFormatTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetReportFormatsTestCase(
+    GmpGetReportFormatsTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225CloneReportFormatTestCase(
+    GmpCloneReportFormatTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ImportReportFormatTestCase(
+    GmpImportReportFormatTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyReportFormatTestCase(
+    GmpModifyReportFormatTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225VerifyReportFormatTestCase(
+    GmpVerifyReportFormatTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_reports.py
+++ b/tests/protocols/gmpv225/entities/test_reports.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,26 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from ...gmpv208.entities.reports import (
+    GmpDeleteReportTestMixin,
+    GmpGetReportsTestMixin,
+    GmpGetReportTestMixin,
+    GmpImportReportTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225DeleteReportTestCase(GmpDeleteReportTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetReportTestCase(GmpGetReportTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetReportsTestCase(GmpGetReportsTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ImportReportTestCase(GmpImportReportTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_resource_names.py
+++ b/tests/protocols/gmpv225/entities/test_resource_names.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from ...gmpv225 import Gmpv225TestCase
+from .resourcenames import (
+    GmpGetResourceNamesListTestMixin,
+    GmpGetResourceNameTestMixin,
+)
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225GetResourceNamesListTestCase(
+    GmpGetResourceNamesListTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetResourceNameTestCase(
+    GmpGetResourceNameTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_results.py
+++ b/tests/protocols/gmpv225/entities/test_results.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from ...gmpv208.entities.results import (
+    GmpGetResultsTestMixin,
+    GmpGetResultTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225GetResultTestCase(GmpGetResultTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetResultsTestCase(GmpGetResultsTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_roles.py
+++ b/tests/protocols/gmpv225/entities/test_roles.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.roles import (
+    GmpCloneRoleTestMixin,
+    GmpCreateRoleTestMixin,
+    GmpDeleteRoleTestMixin,
+    GmpGetRolesTestMixin,
+    GmpGetRoleTestMixin,
+    GmpModifyRoleTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeleteRoleTestCase(GmpDeleteRoleTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetRoleTestCase(GmpGetRoleTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetRolesTestCase(GmpGetRolesTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CloneRoleTestCase(GmpCloneRoleTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateRoleTestCase(GmpCreateRoleTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyRoleTestCase(GmpModifyRoleTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_scan_configs.py
+++ b/tests/protocols/gmpv225/entities/test_scan_configs.py
@@ -1,0 +1,110 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv224.entities.scan_configs import (
+    GmpCloneScanConfigTestMixin,
+    GmpCreateScanConfigTestMixin,
+    GmpDeleteScanConfigTestMixin,
+    GmpGetScanConfigsTestMixin,
+    GmpGetScanConfigTestMixin,
+    GmpImportScanConfigTestMixin,
+    GmpModifyScanConfigSetCommentTestMixin,
+    GmpModifyScanConfigSetFamilySelectionTestMixin,
+    GmpModifyScanConfigSetNameTestMixin,
+    GmpModifyScanConfigSetNvtPreferenceTestMixin,
+    GmpModifyScanConfigSetNvtSelectionTestMixin,
+    GmpModifyScanConfigSetScannerPreferenceTestMixin,
+    GmpModifyScanConfigTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225CloneScanConfigTestCase(
+    GmpCloneScanConfigTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225CreateScanConfigTestCase(
+    GmpCreateScanConfigTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225DeleteScanConfigTestCase(
+    GmpDeleteScanConfigTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetScanConfigTestCase(GmpGetScanConfigTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetScanConfigsTestCase(
+    GmpGetScanConfigsTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ImportScanConfigTestCase(
+    GmpImportScanConfigTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyScanConfigSetCommentTestCase(
+    GmpModifyScanConfigSetCommentTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyScanConfigSetFamilySelectionTestCase(
+    GmpModifyScanConfigSetFamilySelectionTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyScanConfigSetNvtSelectionTestCase(
+    GmpModifyScanConfigSetNvtSelectionTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyScanConfigSetNameTestCase(
+    GmpModifyScanConfigSetNameTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyScanConfigSetNvtPreferenceTestCase(
+    GmpModifyScanConfigSetNvtPreferenceTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyScanConfigSetScannerPreferenceTestCase(
+    GmpModifyScanConfigSetScannerPreferenceTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyScanConfigTestCase(
+    GmpModifyScanConfigTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_scanners.py
+++ b/tests/protocols/gmpv225/entities/test_scanners.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.scanners import (
+    GmpCloneScannerTestMixin,
+    GmpDeleteScannerTestMixin,
+    GmpGetScannersTestMixin,
+    GmpGetScannerTestMixin,
+)
+from ...gmpv224.entities.scanners import (
+    GmpCreateScannerTestMixin,
+    GmpModifyScannerTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeleteScannerTestCase(GmpDeleteScannerTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetScannerTestCase(GmpGetScannerTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetScannersTestCase(GmpGetScannersTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CloneScannerTestCase(GmpCloneScannerTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateScannerTestCase(GmpCreateScannerTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyScannerTestCase(GmpModifyScannerTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_schedules.py
+++ b/tests/protocols/gmpv225/entities/test_schedules.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.schedules import (
+    GmpCloneScheduleTestMixin,
+    GmpCreateScheduleTestMixin,
+    GmpDeleteScheduleTestMixin,
+    GmpGetSchedulesTestMixin,
+    GmpGetScheduleTestMixin,
+    GmpModifyScheduleTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeleteScheduleTestCase(
+    GmpDeleteScheduleTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetScheduleTestCase(GmpGetScheduleTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetSchedulesTestCase(GmpGetSchedulesTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CloneScheduleTestCase(GmpCloneScheduleTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateScheduleTestCase(
+    GmpCreateScheduleTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyScheduleTestCase(
+    GmpModifyScheduleTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_secinfo.py
+++ b/tests/protocols/gmpv225/entities/test_secinfo.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.secinfo import (
+    GmpGetCertBundListTestMixin,
+    GmpGetCertBundTestMixin,
+    GmpGetCpeListTestMixin,
+    GmpGetCpeTestMixin,
+    GmpGetCveListTestMixin,
+    GmpGetCveTestMixin,
+    GmpGetDfnCertListTestMixin,
+    GmpGetDfnCertTestMixin,
+    GmpGetInfoListTestMixin,
+    GmpGetInfoTestMixin,
+    GmpGetNvtFamiliesTestMixin,
+    GmpGetNvtListTestMixin,
+    GmpGetNvtTestMixin,
+    GmpGetOvalDefListTestMixin,
+    GmpGetOvalDefTestMixin,
+    GmpGetScanConfigNvtsTestMixin,
+    GmpGetScanConfigNvtTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225GetCertBundTestCase(GmpGetCertBundTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetCpeTestCase(GmpGetCpeTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetCveTestCase(GmpGetCveTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetDfnCertCase(GmpGetDfnCertTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetOvalDefCase(GmpGetOvalDefTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetInfoListTestCase(GmpGetInfoListTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetInfoTestCase(GmpGetInfoTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetNvtTestCase(GmpGetNvtTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetScanConfigNvtTestCase(
+    GmpGetScanConfigNvtTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetNvtFamiliesTestCase(
+    GmpGetNvtFamiliesTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetScanConfigNvtsTestCase(
+    GmpGetScanConfigNvtsTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetCertBundListTestCase(
+    GmpGetCertBundListTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetCpeListTestCase(GmpGetCpeListTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetCveListTestCase(GmpGetCveListTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetDfnCertListCase(GmpGetDfnCertListTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetNvtListTestCase(GmpGetNvtListTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetOvalDefListTestCase(
+    GmpGetOvalDefListTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_tags.py
+++ b/tests/protocols/gmpv225/entities/test_tags.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.tags import (
+    GmpCloneTagTestMixin,
+    GmpCreateTagTestMixin,
+    GmpDeleteTagTestMixin,
+    GmpGetTagsTestMixin,
+    GmpGetTagTestMixin,
+    GmpModifyTagTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeleteTagTestCase(GmpDeleteTagTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetTagTestCase(GmpGetTagTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetTagsTestCase(GmpGetTagsTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CloneTagTestCase(GmpCloneTagTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateTagTestCase(GmpCreateTagTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyTagTestCase(GmpModifyTagTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_targets.py
+++ b/tests/protocols/gmpv225/entities/test_targets.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.targets import (
+    GmpCloneTargetTestMixin,
+    GmpDeleteTargetTestMixin,
+    GmpGetTargetsTestMixin,
+    GmpGetTargetTestMixin,
+)
+from ...gmpv224.entities.targets import (
+    GmpCreateTargetTestMixin,
+    GmpModifyTargetTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225CloneTargetTestCase(GmpCloneTargetTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateTargetTestCase(GmpCreateTargetTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225DeleteTargetTestCase(GmpDeleteTargetTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetTargetTestCase(GmpGetTargetTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetTargetsTestCase(GmpGetTargetsTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyTargetTestCase(GmpModifyTargetTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_tasks.py
+++ b/tests/protocols/gmpv225/entities/test_tasks.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.tasks import (
+    GmpCloneTaskTestMixin,
+    GmpCreateContainerTaskTestMixin,
+    GmpCreateTaskTestMixin,
+    GmpDeleteTaskTestMixin,
+    GmpGetTasksTestMixin,
+    GmpGetTaskTestMixin,
+    GmpModifyTaskTestMixin,
+    GmpMoveTaskTestMixin,
+    GmpResumeTaskTestMixin,
+    GmpStartTaskTestMixin,
+    GmpStopTaskTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225CloneTaskTestCase(GmpCloneTaskTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateContainerTaskTestCase(
+    GmpCreateContainerTaskTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225CreateTaskTestCase(GmpCreateTaskTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225DeleteTaskTestCase(GmpDeleteTaskTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetTaskTestCase(GmpGetTaskTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetTasksTestCase(GmpGetTasksTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyTaskTestCase(GmpModifyTaskTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225MoveTaskTestCase(GmpMoveTaskTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ResumeTaskTestCase(GmpResumeTaskTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225StartTaskTestCase(GmpStartTaskTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225StopTaskTestCase(GmpStopTaskTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_tickets.py
+++ b/tests/protocols/gmpv225/entities/test_tickets.py
@@ -1,0 +1,51 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.tickets import (
+    GmpCloneTicketTestMixin,
+    GmpCreateTicketTestMixin,
+    GmpDeleteTicketTestMixin,
+    GmpGetTicketsTestMixin,
+    GmpGetTicketTestMixin,
+    GmpModifyTicketTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225DeleteTicketTestCase(GmpDeleteTicketTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetTicketTestCase(GmpGetTicketTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetTicketsTestCase(GmpGetTicketsTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CloneTicketTestCase(GmpCloneTicketTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateTicketTestCase(GmpCreateTicketTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyTicketTestCase(GmpModifyTicketTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/entities/test_tls_certificates.py
+++ b/tests/protocols/gmpv225/entities/test_tls_certificates.py
@@ -1,0 +1,63 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from ...gmpv208.entities.tls_certificates import (
+    GmpCloneTLSCertificateTestMixin,
+    GmpCreateTLSCertificateTestMixin,
+    GmpDeleteTLSCertificateTestMixin,
+    GmpGetTLSCertificatesTestMixin,
+    GmpGetTLSCertificateTestMixin,
+    GmpModifyTLSCertificateTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225CloneTLSCertificateTestCase(
+    GmpCloneTLSCertificateTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225CreateTLSCertificateTestCase(
+    GmpCreateTLSCertificateTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225DeleteTLSCertificateTestCase(
+    GmpDeleteTLSCertificateTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetTLSCertificateTestCase(
+    GmpGetTLSCertificateTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetTLSCertificatesTestCase(
+    GmpGetTLSCertificatesTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyTLSCertificateTestCase(
+    GmpModifyTLSCertificateTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/entities/test_users.py
+++ b/tests/protocols/gmpv225/entities/test_users.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from unittest.mock import call, patch
+
+from ...gmpv208.entities.users import (
+    GmpCloneUserTestMixin,
+    GmpDeleteUserTestMixin,
+    GmpGetUsersTestMixin,
+    GmpGetUserTestMixin,
+)
+from ...gmpv224.entities.users import (
+    GmpCreateUserTestMixin,
+    GmpModifyUserTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
+
+
+class Gmpv225CloneUserTestCase(GmpCloneUserTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225CreateUserTestCase(GmpCreateUserTestMixin, Gmpv225TestCase):
+    @patch("gvm.protocols.gmpv224.entities.users.deprecation")
+    def test_create_user_with_ifaces(self, deprecation_mock):
+        self.gmp.create_user(name="foo", ifaces=["h1", "h2"], ifaces_allow=True)
+
+        self.connection.send.has_been_called_with(
+            "<create_user><name>foo</name></create_user>"
+        )
+
+        self.gmp.create_user(name="foo", ifaces=["h1", "h2"])
+
+        self.connection.send.has_been_called_with(
+            "<create_user><name>foo</name></create_user>"
+        )
+
+        self.gmp.create_user(
+            name="foo", ifaces=["h1", "h2"], ifaces_allow=False
+        )
+
+        self.connection.send.has_been_called_with(
+            "<create_user><name>foo</name></create_user>"
+        )
+
+        # pylint: disable=line-too-long
+        deprecation_calls = [
+            call("The ifaces parameter has been removed in GMP version 225"),
+            call(
+                "The ifaces_allow parameter has been removed in GMP version 225"
+            ),
+            call("The ifaces parameter has been removed in GMP version 225"),
+            call("The ifaces parameter has been removed in GMP version 225"),
+            call(
+                "The ifaces_allow parameter has been removed in GMP version 225"
+            ),
+        ]
+        # pylint: enable=line-too-long
+        deprecation_mock.assert_has_calls(deprecation_calls)
+
+
+class Gmpv225DeleteUserTestCase(GmpDeleteUserTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetUserTestCase(GmpGetUserTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225GetUsersTestCase(GmpGetUsersTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyUserTestCase(GmpModifyUserTestMixin, Gmpv225TestCase):
+    @patch("gvm.protocols.gmpv224.entities.users.deprecation")
+    def test_modify_user_with_ifaces(self, deprecation_mock):
+        self.gmp.modify_user(user_id="u1", ifaces=[])
+
+        self.connection.send.has_been_called_with('<modify_user user_id="u1"/>')
+
+        self.gmp.modify_user(user_id="u2", ifaces=["foo"])
+
+        self.connection.send.has_been_called_with('<modify_user user_id="u2"/>')
+
+        self.gmp.modify_user(user_id="u3", ifaces=["foo", "bar"])
+
+        self.connection.send.has_been_called_with('<modify_user user_id="u3"/>')
+
+        self.gmp.modify_user(
+            user_id="u4", ifaces=["foo", "bar"], ifaces_allow=False
+        )
+
+        self.connection.send.has_been_called_with('<modify_user user_id="u4"/>')
+
+        self.gmp.modify_user(
+            user_id="u5", ifaces=["foo", "bar"], ifaces_allow=True
+        )
+
+        self.connection.send.has_been_called_with('<modify_user user_id="u5"/>')
+
+        # pylint: disable=line-too-long
+        deprecation_calls = [
+            call("The ifaces parameter has been removed in GMP version 225"),
+            call("The ifaces parameter has been removed in GMP version 225"),
+            call("The ifaces parameter has been removed in GMP version 225"),
+            call(
+                "The ifaces_allow parameter has been removed in GMP version 225"
+            ),
+            call("The ifaces parameter has been removed in GMP version 225"),
+            call(
+                "The ifaces_allow parameter has been removed in GMP version 225"
+            ),
+        ]
+        # pylint: enable=line-too-long
+        deprecation_mock.assert_has_calls(deprecation_calls)

--- a/tests/protocols/gmpv225/entities/test_vulnerabilities.py
+++ b/tests/protocols/gmpv225/entities/test_vulnerabilities.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from ...gmpv208.entities.vulnerabilities import (
+    GmpGetVulnerabilitiesTestMixin,
+    GmpGetVulnerabilityTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225GetVulnerabilityTestCase(
+    GmpGetVulnerabilityTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetVulnerabilitiesTestCase(
+    GmpGetVulnerabilitiesTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/enums/__init__.py
+++ b/tests/protocols/gmpv225/enums/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -15,21 +15,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_aggregate_statistic.py
+++ b/tests/protocols/gmpv225/enums/test_aggregate_statistic.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import AggregateStatistic
+
+
+class GetAggregateStatisticFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            AggregateStatistic.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = AggregateStatistic.from_string(None)
+        self.assertIsNone(ct)
+        ct = AggregateStatistic.from_string("")
+        self.assertIsNone(ct)
+
+    def test_count(self):
+        ct = AggregateStatistic.from_string("count")
+        self.assertEqual(ct, AggregateStatistic.COUNT)
+
+    def test_c_count(self):
+        ct = AggregateStatistic.from_string("c_count")
+        self.assertEqual(ct, AggregateStatistic.C_COUNT)
+
+    def test_c_sum(self):
+        ct = AggregateStatistic.from_string("c_sum")
+        self.assertEqual(ct, AggregateStatistic.C_SUM)
+
+    def test_max(self):
+        ct = AggregateStatistic.from_string("max")
+        self.assertEqual(ct, AggregateStatistic.MAX)
+
+    def test_mean(self):
+        ct = AggregateStatistic.from_string("mean")
+        self.assertEqual(ct, AggregateStatistic.MEAN)
+
+    def test_min(self):
+        ct = AggregateStatistic.from_string("min")
+        self.assertEqual(ct, AggregateStatistic.MIN)
+
+    def test_sum(self):
+        ct = AggregateStatistic.from_string("sum")
+        self.assertEqual(ct, AggregateStatistic.SUM)
+
+    def test_text(self):
+        ct = AggregateStatistic.from_string("text")
+        self.assertEqual(ct, AggregateStatistic.TEXT)
+
+    def test_value(self):
+        ct = AggregateStatistic.from_string("value")
+        self.assertEqual(ct, AggregateStatistic.VALUE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_alert_condition.py
+++ b/tests/protocols/gmpv225/enums/test_alert_condition.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import AlertCondition
+
+
+class GetAlertConditionFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            AlertCondition.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = AlertCondition.from_string(None)
+        self.assertIsNone(ct)
+        ct = AlertCondition.from_string("")
+        self.assertIsNone(ct)
+
+    def test_always(self):
+        ct = AlertCondition.from_string("always")
+        self.assertEqual(ct, AlertCondition.ALWAYS)
+
+    def test_filter_count_at_least(self):
+        ct = AlertCondition.from_string("filter count at least")
+        self.assertEqual(ct, AlertCondition.FILTER_COUNT_AT_LEAST)
+
+    def test_filter_count_changed(self):
+        ct = AlertCondition.from_string("filter count changed")
+        self.assertEqual(ct, AlertCondition.FILTER_COUNT_CHANGED)
+
+    def test_severity_at_least(self):
+        ct = AlertCondition.from_string("severity at least")
+        self.assertEqual(ct, AlertCondition.SEVERITY_AT_LEAST)
+
+    def test_severity_changed(self):
+        ct = AlertCondition.from_string("severity changed")
+        self.assertEqual(ct, AlertCondition.SEVERITY_CHANGED)
+
+    def test_error(self):
+        ct = AlertCondition.from_string("error")
+        self.assertEqual(ct, AlertCondition.ERROR)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_alert_event.py
+++ b/tests/protocols/gmpv225/enums/test_alert_event.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import AlertEvent
+
+
+class GetAlertEventFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            AlertEvent.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = AlertEvent.from_string(None)
+        self.assertIsNone(ct)
+        ct = AlertEvent.from_string("")
+        self.assertIsNone(ct)
+
+    def test_task_run_status_changed(self):
+        ct = AlertEvent.from_string("Task run status changed")
+        self.assertEqual(ct, AlertEvent.TASK_RUN_STATUS_CHANGED)
+
+    def test_new_secinfo_arrived(self):
+        ct = AlertEvent.from_string("New SecInfo arrived")
+        self.assertEqual(ct, AlertEvent.NEW_SECINFO_ARRIVED)
+
+    def test_updated_secinfo_arrived(self):
+        ct = AlertEvent.from_string("Updated SecInfo arrived")
+        self.assertEqual(ct, AlertEvent.UPDATED_SECINFO_ARRIVED)
+
+    def test_ticket_received(self):
+        ct = AlertEvent.from_string("ticket received")
+        self.assertEqual(ct, AlertEvent.TICKET_RECEIVED)
+
+    def test_assigned_ticket_changed(self):
+        ct = AlertEvent.from_string("assigned ticket changed")
+        self.assertEqual(ct, AlertEvent.ASSIGNED_TICKET_CHANGED)
+
+    def test_owned_ticket_changed(self):
+        ct = AlertEvent.from_string("owned ticket changed")
+        self.assertEqual(ct, AlertEvent.OWNED_TICKET_CHANGED)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_alert_method.py
+++ b/tests/protocols/gmpv225/enums/test_alert_method.py
@@ -1,0 +1,86 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import AlertMethod
+
+
+class GetAlertMethodFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            AlertMethod.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = AlertMethod.from_string(None)
+        self.assertIsNone(ct)
+        ct = AlertMethod.from_string("")
+        self.assertIsNone(ct)
+
+    def test_email(self):
+        ct = AlertMethod.from_string("email")
+        self.assertEqual(ct, AlertMethod.EMAIL)
+
+    def test_scp(self):
+        ct = AlertMethod.from_string("scp")
+        self.assertEqual(ct, AlertMethod.SCP)
+
+    def test_send(self):
+        ct = AlertMethod.from_string("send")
+        self.assertEqual(ct, AlertMethod.SEND)
+
+    def test_smb(self):
+        ct = AlertMethod.from_string("smb")
+        self.assertEqual(ct, AlertMethod.SMB)
+
+    def test_snmp(self):
+        ct = AlertMethod.from_string("snmp")
+        self.assertEqual(ct, AlertMethod.SNMP)
+
+    def test_syslog(self):
+        ct = AlertMethod.from_string("syslog")
+        self.assertEqual(ct, AlertMethod.SYSLOG)
+
+    def test_http_get(self):
+        ct = AlertMethod.from_string("HTTP Get")
+        self.assertEqual(ct, AlertMethod.HTTP_GET)
+
+    def test_start_task(self):
+        ct = AlertMethod.from_string("Start Task")
+        self.assertEqual(ct, AlertMethod.START_TASK)
+
+    def test_sourcefire_connector(self):
+        ct = AlertMethod.from_string("sourcefire Connector")
+        self.assertEqual(ct, AlertMethod.SOURCEFIRE_CONNECTOR)
+
+    def test_verinice_connector(self):
+        ct = AlertMethod.from_string("verinice Connector")
+        self.assertEqual(ct, AlertMethod.VERINICE_CONNECTOR)
+
+    def test_tippingpoint_sms(self):
+        ct = AlertMethod.from_string("Tippingpoint SMS")
+        self.assertEqual(ct, AlertMethod.TIPPINGPOINT_SMS)
+
+    def test_alemba_vfire(self):
+        ct = AlertMethod.from_string("Alemba vFire")
+        self.assertEqual(ct, AlertMethod.ALEMBA_VFIRE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_alive_test.py
+++ b/tests/protocols/gmpv225/enums/test_alive_test.py
@@ -1,0 +1,78 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import AliveTest
+
+
+class GetAliveTestFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            AliveTest.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = AliveTest.from_string(None)
+        self.assertIsNone(ct)
+        ct = AliveTest.from_string("")
+        self.assertIsNone(ct)
+
+    def test_scan_config_default(self):
+        ct = AliveTest.from_string("Scan Config Default")
+        self.assertEqual(ct, AliveTest.SCAN_CONFIG_DEFAULT)
+
+    def test_icmp_ping(self):
+        ct = AliveTest.from_string("ICMP Ping")
+        self.assertEqual(ct, AliveTest.ICMP_PING)
+
+    def test_tcp_ack_service_ping(self):
+        ct = AliveTest.from_string("TCP-ACK Service Ping")
+        self.assertEqual(ct, AliveTest.TCP_ACK_SERVICE_PING)
+
+    def test_tcp_sync_service_ping(self):
+        ct = AliveTest.from_string("TCP-SYN Service Ping")
+        self.assertEqual(ct, AliveTest.TCP_SYN_SERVICE_PING)
+
+    def test_arp_ping(self):
+        ct = AliveTest.from_string("ARP Ping")
+        self.assertEqual(ct, AliveTest.ARP_PING)
+
+    def test_icmp_and_tcp_ack_service_ping(self):
+        ct = AliveTest.from_string("ICMP & TCP-ACK Service Ping")
+        self.assertEqual(ct, AliveTest.ICMP_AND_TCP_ACK_SERVICE_PING)
+
+    def test_icmp_and_arp_ping(self):
+        ct = AliveTest.from_string("ICMP & ARP Ping")
+        self.assertEqual(ct, AliveTest.ICMP_AND_ARP_PING)
+
+    def test_tcp_ack_service_and_arp_ping(self):
+        ct = AliveTest.from_string("TCP-ACK Service & ARP Ping")
+        self.assertEqual(ct, AliveTest.TCP_ACK_SERVICE_AND_ARP_PING)
+
+    def test_icmp_tcp_ack_service_and_arp_ping(self):
+        ct = AliveTest.from_string("ICMP, TCP-ACK Service & ARP Ping")
+        self.assertEqual(ct, AliveTest.ICMP_TCP_ACK_SERVICE_AND_ARP_PING)
+
+    def test_consider_alive(self):
+        ct = AliveTest.from_string("Consider Alive")
+        self.assertEqual(ct, AliveTest.CONSIDER_ALIVE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_credential_format.py
+++ b/tests/protocols/gmpv225/enums/test_credential_format.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import CredentialFormat
+
+
+class GetCredentialFromatFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            CredentialFormat.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = CredentialFormat.from_string(None)
+        self.assertIsNone(ct)
+        ct = CredentialFormat.from_string("")
+        self.assertIsNone(ct)
+
+    def test_key(self):
+        ct = CredentialFormat.from_string("key")
+        self.assertEqual(ct, CredentialFormat.KEY)
+
+    def test_rpm(self):
+        ct = CredentialFormat.from_string("rpm")
+        self.assertEqual(ct, CredentialFormat.RPM)
+
+    def test_deb(self):
+        ct = CredentialFormat.from_string("deb")
+        self.assertEqual(ct, CredentialFormat.DEB)
+
+    def test_exe(self):
+        ct = CredentialFormat.from_string("exe")
+        self.assertEqual(ct, CredentialFormat.EXE)
+
+    def test_pem(self):
+        ct = CredentialFormat.from_string("pem")
+        self.assertEqual(ct, CredentialFormat.PEM)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_credential_type.py
+++ b/tests/protocols/gmpv225/enums/test_credential_type.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import CredentialType
+
+
+class GetCredentialTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid_type(self):
+        with self.assertRaises(InvalidArgument):
+            CredentialType.from_string("foo")
+
+    def test_none_or_empty_type(self):
+        ct = CredentialType.from_string(None)
+        self.assertIsNone(ct)
+        ct = CredentialType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_client_certificate(self):
+        ct = CredentialType.from_string("client_certificate")
+        self.assertEqual(ct, CredentialType.CLIENT_CERTIFICATE)
+
+    def test_snmp(self):
+        ct = CredentialType.from_string("snmp")
+        self.assertEqual(ct, CredentialType.SNMP)
+
+    def test_username_password(self):
+        ct = CredentialType.from_string("username_password")
+        self.assertEqual(ct, CredentialType.USERNAME_PASSWORD)
+
+    def test_username_ssh_key(self):
+        ct = CredentialType.from_string("username_ssh_key")
+        self.assertEqual(ct, CredentialType.USERNAME_SSH_KEY)
+
+    def test_smime_certificate(self):
+        ct = CredentialType.from_string("smime_certificate")
+        self.assertEqual(ct, CredentialType.SMIME_CERTIFICATE)
+
+    def test_pgp_encryption_key(self):
+        ct = CredentialType.from_string("pgp_encryption_key")
+        self.assertEqual(ct, CredentialType.PGP_ENCRYPTION_KEY)
+
+    def test_password_only(self):
+        ct = CredentialType.from_string("password_only")
+        self.assertEqual(ct, CredentialType.PASSWORD_ONLY)

--- a/tests/protocols/gmpv225/enums/test_entity_type.py
+++ b/tests/protocols/gmpv225/enums/test_entity_type.py
@@ -1,0 +1,179 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import EntityType
+
+
+class GetEntityTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            EntityType.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = EntityType.from_string(None)
+        self.assertIsNone(ct)
+        ct = EntityType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_audit(self):
+        ct = EntityType.from_string("audit")
+        self.assertEqual(ct, EntityType.AUDIT)
+
+    def test_alert(self):
+        ct = EntityType.from_string("alert")
+        self.assertEqual(ct, EntityType.ALERT)
+
+    def test_asset(self):
+        ct = EntityType.from_string("asset")
+        self.assertEqual(ct, EntityType.ASSET)
+
+    def test_cert_bund_adv(self):
+        ct = EntityType.from_string("cert_bund_adv")
+        self.assertEqual(ct, EntityType.CERT_BUND_ADV)
+
+    def test_cpe(self):
+        ct = EntityType.from_string("cpe")
+        self.assertEqual(ct, EntityType.CPE)
+
+    def test_credential(self):
+        ct = EntityType.from_string("credential")
+        self.assertEqual(ct, EntityType.CREDENTIAL)
+
+    def test_dfn_cert_adv(self):
+        ct = EntityType.from_string("dfn_cert_adv")
+        self.assertEqual(ct, EntityType.DFN_CERT_ADV)
+
+    def test_filter(self):
+        ct = EntityType.from_string("filter")
+        self.assertEqual(ct, EntityType.FILTER)
+
+    def test_group(self):
+        ct = EntityType.from_string("group")
+        self.assertEqual(ct, EntityType.GROUP)
+
+    def test_host(self):
+        ct = EntityType.from_string("host")
+        self.assertEqual(ct, EntityType.HOST)
+
+    def test_info(self):
+        ct = EntityType.from_string("info")
+        self.assertEqual(ct, EntityType.INFO)
+
+    def test_note(self):
+        ct = EntityType.from_string("note")
+        self.assertEqual(ct, EntityType.NOTE)
+
+    def test_nvt(self):
+        ct = EntityType.from_string("nvt")
+        self.assertEqual(ct, EntityType.NVT)
+
+    def test_operating_system(self):
+        ct = EntityType.from_string("os")
+        self.assertEqual(ct, EntityType.OPERATING_SYSTEM)
+
+        ct = EntityType.from_string("operating_system")
+        self.assertEqual(ct, EntityType.OPERATING_SYSTEM)
+
+    def test_ovaldef(self):
+        ct = EntityType.from_string("ovaldef")
+        self.assertEqual(ct, EntityType.OVALDEF)
+
+    def test_override(self):
+        ct = EntityType.from_string("override")
+        self.assertEqual(ct, EntityType.OVERRIDE)
+
+    def test_permission(self):
+        ct = EntityType.from_string("permission")
+        self.assertEqual(ct, EntityType.PERMISSION)
+
+    def test_policy(self):
+        ct = EntityType.from_string("policy")
+        self.assertEqual(ct, EntityType.POLICY)
+
+    def test_port_list(self):
+        ct = EntityType.from_string("port_list")
+        self.assertEqual(ct, EntityType.PORT_LIST)
+
+    def test_report(self):
+        ct = EntityType.from_string("report")
+        self.assertEqual(ct, EntityType.REPORT)
+
+    def test_report_format(self):
+        ct = EntityType.from_string("report_format")
+        self.assertEqual(ct, EntityType.REPORT_FORMAT)
+
+    def test_result(self):
+        ct = EntityType.from_string("result")
+        self.assertEqual(ct, EntityType.RESULT)
+
+    def test_role(self):
+        ct = EntityType.from_string("role")
+        self.assertEqual(ct, EntityType.ROLE)
+
+    def test_scan_config(self):
+        ct = EntityType.from_string("config")
+        self.assertEqual(ct, EntityType.SCAN_CONFIG)
+
+        ct = EntityType.from_string("scan_config")
+        self.assertEqual(ct, EntityType.SCAN_CONFIG)
+
+    def test_scanner(self):
+        ct = EntityType.from_string("scanner")
+        self.assertEqual(ct, EntityType.SCANNER)
+
+    def test_schedule(self):
+        ct = EntityType.from_string("schedule")
+        self.assertEqual(ct, EntityType.SCHEDULE)
+
+    def test_tag(self):
+        ct = EntityType.from_string("tag")
+        self.assertEqual(ct, EntityType.TAG)
+
+    def test_target(self):
+        ct = EntityType.from_string("target")
+        self.assertEqual(ct, EntityType.TARGET)
+
+    def test_task(self):
+        ct = EntityType.from_string("task")
+        self.assertEqual(ct, EntityType.TASK)
+
+    def test_ticket(self):
+        ct = EntityType.from_string("ticket")
+        self.assertEqual(ct, EntityType.TICKET)
+
+    def test_tls_certificate(self):
+        ft = EntityType.from_string("tls_certificate")
+        self.assertEqual(ft, EntityType.TLS_CERTIFICATE)
+
+    def test_user(self):
+        ct = EntityType.from_string("user")
+        self.assertEqual(ct, EntityType.USER)
+
+    def test_vulnerability(self):
+        ct = EntityType.from_string("vuln")
+        self.assertEqual(ct, EntityType.VULNERABILITY)
+
+        ct = EntityType.from_string("vulnerability")
+        self.assertEqual(ct, EntityType.VULNERABILITY)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_feed_type.py
+++ b/tests/protocols/gmpv225/enums/test_feed_type.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import FeedType
+
+
+class GetFeedTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            FeedType.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = FeedType.from_string(None)
+        self.assertIsNone(ct)
+        ct = FeedType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_nvt(self):
+        ct = FeedType.from_string("nvt")
+        self.assertEqual(ct, FeedType.NVT)
+
+    def test_cert(self):
+        ct = FeedType.from_string("cert")
+        self.assertEqual(ct, FeedType.CERT)
+
+    def test_scap(self):
+        ct = FeedType.from_string("scap")
+        self.assertEqual(ct, FeedType.SCAP)
+
+    def test_gvmd_data(self):
+        ct = FeedType.from_string("gvmd_data")
+        self.assertEqual(ct, FeedType.GVMD_DATA)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_filter_type.py
+++ b/tests/protocols/gmpv225/enums/test_filter_type.py
@@ -1,0 +1,151 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import FilterType
+
+
+class GetFilterTypeFomStringTestCase(unittest.TestCase):
+    def test_filter_type_alert(self):
+        ft = FilterType.from_string("alert")
+        self.assertEqual(ft, FilterType.ALERT)
+
+    def test_filter_type_asset(self):
+        ft = FilterType.from_string("asset")
+        self.assertEqual(ft, FilterType.ASSET)
+
+    def test_filter_type_credential(self):
+        ft = FilterType.from_string("credential")
+        self.assertEqual(ft, FilterType.CREDENTIAL)
+
+    def test_filter_type_filter(self):
+        ft = FilterType.from_string("filter")
+        self.assertEqual(ft, FilterType.FILTER)
+
+    def test_filter_type_group(self):
+        ft = FilterType.from_string("group")
+        self.assertEqual(ft, FilterType.GROUP)
+
+    def test_filter_type_host(self):
+        ft = FilterType.from_string("host")
+        self.assertEqual(ft, FilterType.HOST)
+
+    def test_filter_type_note(self):
+        ft = FilterType.from_string("note")
+        self.assertEqual(ft, FilterType.NOTE)
+
+    def test_filter_type_override(self):
+        ft = FilterType.from_string("override")
+        self.assertEqual(ft, FilterType.OVERRIDE)
+
+    def test_filter_type_permission(self):
+        ft = FilterType.from_string("permission")
+        self.assertEqual(ft, FilterType.PERMISSION)
+
+    def test_filter_type_port_list(self):
+        ft = FilterType.from_string("port_list")
+        self.assertEqual(ft, FilterType.PORT_LIST)
+
+    def test_filter_type_report(self):
+        ft = FilterType.from_string("report")
+        self.assertEqual(ft, FilterType.REPORT)
+
+    def test_filter_type_report_format(self):
+        ft = FilterType.from_string("report_format")
+        self.assertEqual(ft, FilterType.REPORT_FORMAT)
+
+    def test_filter_type_result(self):
+        ft = FilterType.from_string("result")
+        self.assertEqual(ft, FilterType.RESULT)
+
+    def test_filter_type_role(self):
+        ft = FilterType.from_string("role")
+        self.assertEqual(ft, FilterType.ROLE)
+
+    def test_filter_type_schedule(self):
+        ft = FilterType.from_string("schedule")
+        self.assertEqual(ft, FilterType.SCHEDULE)
+
+    def test_filter_type_secinfo(self):
+        ft = FilterType.from_string("secinfo")
+        self.assertEqual(ft, FilterType.ALL_SECINFO)
+
+    def test_filter_type_all_secinfo(self):
+        ft = FilterType.from_string("all_secinfo")
+        self.assertEqual(ft, FilterType.ALL_SECINFO)
+
+    def test_filter_type_tag(self):
+        ft = FilterType.from_string("tag")
+        self.assertEqual(ft, FilterType.TAG)
+
+    def test_filter_type_task(self):
+        ft = FilterType.from_string("task")
+        self.assertEqual(ft, FilterType.TASK)
+
+    def test_filter_type_target(self):
+        ft = FilterType.from_string("target")
+        self.assertEqual(ft, FilterType.TARGET)
+
+    def test_filter_type_ticket(self):
+        ft = FilterType.from_string("ticket")
+        self.assertEqual(ft, FilterType.TICKET)
+
+    def test_filter_type_tls_certificate(self):
+        ft = FilterType.from_string("tls_certificate")
+        self.assertEqual(ft, FilterType.TLS_CERTIFICATE)
+
+    def test_filter_type_operating_system(self):
+        ft = FilterType.from_string("operating_system")
+        self.assertEqual(ft, FilterType.OPERATING_SYSTEM)
+
+    def test_filter_type_user(self):
+        ft = FilterType.from_string("user")
+        self.assertEqual(ft, FilterType.USER)
+
+    def test_filter_type_vuln(self):
+        ft = FilterType.from_string("vuln")
+        self.assertEqual(ft, FilterType.VULNERABILITY)
+
+    def test_filter_type_vulnerability(self):
+        ft = FilterType.from_string("vulnerability")
+        self.assertEqual(ft, FilterType.VULNERABILITY)
+
+    def test_filter_type_config(self):
+        ft = FilterType.from_string("config")
+        self.assertEqual(ft, FilterType.SCAN_CONFIG)
+
+    def test_filter_type_scan_config(self):
+        ft = FilterType.from_string("scan_config")
+        self.assertEqual(ft, FilterType.SCAN_CONFIG)
+
+    def test_filter_type_os(self):
+        ft = FilterType.from_string("os")
+        self.assertEqual(ft, FilterType.OPERATING_SYSTEM)
+
+    def test_invalid_filter_type(self):
+        with self.assertRaises(InvalidArgument):
+            FilterType.from_string("foo")
+
+    def test_non_or_empty_filter_type(self):
+        ft = FilterType.from_string(None)
+        self.assertIsNone(ft)
+
+        ft = FilterType.from_string("")
+        self.assertIsNone(ft)

--- a/tests/protocols/gmpv225/enums/test_help_format.py
+++ b/tests/protocols/gmpv225/enums/test_help_format.py
@@ -1,0 +1,54 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import HelpFormat
+
+
+class GetHelpFormatFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            HelpFormat.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = HelpFormat.from_string(None)
+        self.assertIsNone(ct)
+        ct = HelpFormat.from_string("")
+        self.assertIsNone(ct)
+
+    def test_task_run_status_changed(self):
+        ct = HelpFormat.from_string("HtMl")
+        self.assertEqual(ct, HelpFormat.HTML)
+
+    def test_new_secinfo_arrived(self):
+        ct = HelpFormat.from_string("rNc")
+        self.assertEqual(ct, HelpFormat.RNC)
+
+    def test_updated_secinfo_arrived(self):
+        ct = HelpFormat.from_string("tExT")
+        self.assertEqual(ct, HelpFormat.TEXT)
+
+    def test_ticket_received(self):
+        ct = HelpFormat.from_string("XmL")
+        self.assertEqual(ct, HelpFormat.XML)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_hosts_ordering.py
+++ b/tests/protocols/gmpv225/enums/test_hosts_ordering.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import HostsOrdering
+
+
+class GetHostsOrderingFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            HostsOrdering.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = HostsOrdering.from_string(None)
+        self.assertIsNone(ct)
+        ct = HostsOrdering.from_string("")
+        self.assertIsNone(ct)
+
+    def test_sequential(self):
+        ct = HostsOrdering.from_string("sequential")
+        self.assertEqual(ct, HostsOrdering.SEQUENTIAL)
+
+    def test_random(self):
+        ct = HostsOrdering.from_string("random")
+        self.assertEqual(ct, HostsOrdering.RANDOM)
+
+    def test_reverse(self):
+        ct = HostsOrdering.from_string("reverse")
+        self.assertEqual(ct, HostsOrdering.REVERSE)

--- a/tests/protocols/gmpv225/enums/test_info_type copy.py
+++ b/tests/protocols/gmpv225/enums/test_info_type copy.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import InfoType
+
+
+class GetInfoTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            InfoType.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = InfoType.from_string(None)
+        self.assertIsNone(ct)
+        ct = InfoType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_cert_bund_adv(self):
+        ct = InfoType.from_string("cert_bund_adv")
+        self.assertEqual(ct, InfoType.CERT_BUND_ADV)
+
+    def test_cpe(self):
+        ct = InfoType.from_string("cpe")
+        self.assertEqual(ct, InfoType.CPE)
+
+    def test_cve(self):
+        ct = InfoType.from_string("cve")
+        self.assertEqual(ct, InfoType.CVE)
+
+    def test_dfn_cert_adv(self):
+        ct = InfoType.from_string("dfn_cert_adv")
+        self.assertEqual(ct, InfoType.DFN_CERT_ADV)
+
+    def test_nvt(self):
+        ct = InfoType.from_string("nvt")
+        self.assertEqual(ct, InfoType.NVT)
+
+    def test_ovaldef(self):
+        ct = InfoType.from_string("ovaldef")
+        self.assertEqual(ct, InfoType.OVALDEF)
+
+    def test_allinfo(self):
+        with self.assertRaises(InvalidArgument):
+            InfoType.from_string("allinfo")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_permission_subject_type.py
+++ b/tests/protocols/gmpv225/enums/test_permission_subject_type.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import PermissionSubjectType
+
+
+class GetPermissionSubjectTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            PermissionSubjectType.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = PermissionSubjectType.from_string(None)
+        self.assertIsNone(ct)
+        ct = PermissionSubjectType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_user(self):
+        ct = PermissionSubjectType.from_string("user")
+        self.assertEqual(ct, PermissionSubjectType.USER)
+
+    def test_role(self):
+        ct = PermissionSubjectType.from_string("role")
+        self.assertEqual(ct, PermissionSubjectType.ROLE)
+
+    def test_group(self):
+        ct = PermissionSubjectType.from_string("group")
+        self.assertEqual(ct, PermissionSubjectType.GROUP)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_port_range_type.py
+++ b/tests/protocols/gmpv225/enums/test_port_range_type.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,19 +16,30 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
 import unittest
 
-from gvm.protocols.next import Gmp, Osp
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import PortRangeType
 
 
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
+class GetPortRangeTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            PortRangeType.from_string("foo")
 
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+    def test_none_or_empty(self):
+        ct = PortRangeType.from_string(None)
+        self.assertIsNone(ct)
+        ct = PortRangeType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_tcp(self):
+        ct = PortRangeType.from_string("tcp")
+        self.assertEqual(ct, PortRangeType.TCP)
+
+    def test_udp(self):
+        ct = PortRangeType.from_string("udp")
+        self.assertEqual(ct, PortRangeType.UDP)
 
 
 if __name__ == "__main__":

--- a/tests/protocols/gmpv225/enums/test_report_format_type.py
+++ b/tests/protocols/gmpv225/enums/test_report_format_type.py
@@ -1,0 +1,114 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import ReportFormatType
+
+
+class GetPortRangeTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            ReportFormatType.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = ReportFormatType.from_string(None)
+        self.assertIsNone(ct)
+        ct = ReportFormatType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_anonymous_pdf(self):
+        ct = ReportFormatType.from_string("anonymous xml")
+        self.assertEqual(ct, ReportFormatType.ANONYMOUS_XML)
+
+    def test_arf(self):
+        ct = ReportFormatType.from_string("arf")
+        self.assertEqual(ct, ReportFormatType.ARF)
+
+    def test_(self):
+        ct = ReportFormatType.from_string("cpe")
+        self.assertEqual(ct, ReportFormatType.CPE)
+
+    def test_csv_hosts(self):
+        ct = ReportFormatType.from_string("csv hosts")
+        self.assertEqual(ct, ReportFormatType.CSV_HOSTS)
+
+    def test_csv_results(self):
+        ct = ReportFormatType.from_string("csv results")
+        self.assertEqual(ct, ReportFormatType.CSV_RESULTS)
+
+    def test_gcr_pdf(self):
+        ct = ReportFormatType.from_string("gcr pdf")
+        self.assertEqual(ct, ReportFormatType.GCR_PDF)
+
+    def test_gsr_html(self):
+        ct = ReportFormatType.from_string("gsr html")
+        self.assertEqual(ct, ReportFormatType.GSR_HTML)
+
+    def test_gsr_pdf(self):
+        ct = ReportFormatType.from_string("gsr pdf")
+        self.assertEqual(ct, ReportFormatType.GSR_PDF)
+
+    def test_gxcr_pdf(self):
+        ct = ReportFormatType.from_string("gxcr pdf")
+        self.assertEqual(ct, ReportFormatType.GXCR_PDF)
+
+    def test_gxr_pdf(self):
+        ct = ReportFormatType.from_string("gxr pdf")
+        self.assertEqual(ct, ReportFormatType.GXR_PDF)
+
+    def test_itg(self):
+        ct = ReportFormatType.from_string("itg")
+        self.assertEqual(ct, ReportFormatType.ITG)
+
+    def test_latex(self):
+        ct = ReportFormatType.from_string("latex")
+        self.assertEqual(ct, ReportFormatType.LATEX)
+
+    def test_nbe(self):
+        ct = ReportFormatType.from_string("nbe")
+        self.assertEqual(ct, ReportFormatType.NBE)
+
+    def test_pdf(self):
+        ct = ReportFormatType.from_string("pdf")
+        self.assertEqual(ct, ReportFormatType.PDF)
+
+    def test_svg(self):
+        ct = ReportFormatType.from_string("svg")
+        self.assertEqual(ct, ReportFormatType.SVG)
+
+    def test_txt(self):
+        ct = ReportFormatType.from_string("txt")
+        self.assertEqual(ct, ReportFormatType.TXT)
+
+    def test_verinice_ism(self):
+        ct = ReportFormatType.from_string("verinice ism")
+        self.assertEqual(ct, ReportFormatType.VERINICE_ISM)
+
+    def test_verinice_itg(self):
+        ct = ReportFormatType.from_string("verinice itg")
+        self.assertEqual(ct, ReportFormatType.VERINICE_ITG)
+
+    def test_xml(self):
+        ct = ReportFormatType.from_string("xml")
+        self.assertEqual(ct, ReportFormatType.XML)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_resource_type.py
+++ b/tests/protocols/gmpv225/enums/test_resource_type.py
@@ -1,0 +1,146 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import ResourceType
+
+
+class GetResourceTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            ResourceType.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = ResourceType.from_string(None)
+        self.assertIsNone(ct)
+        ct = ResourceType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_alert(self):
+        ct = ResourceType.from_string("alert")
+        self.assertEqual(ct, ResourceType.ALERT)
+
+    def test_cert_bund_adv(self):
+        ct = ResourceType.from_string("cert_bund_adv")
+        self.assertEqual(ct, ResourceType.CERT_BUND_ADV)
+
+    def test_config(self):
+        ct = ResourceType.from_string("config")
+        self.assertEqual(ct, ResourceType.CONFIG)
+
+    def test_cpe(self):
+        ct = ResourceType.from_string("cpe")
+        self.assertEqual(ct, ResourceType.CPE)
+
+    def test_credential(self):
+        ct = ResourceType.from_string("credential")
+        self.assertEqual(ct, ResourceType.CREDENTIAL)
+
+    def test_cve(self):
+        ct = ResourceType.from_string("cve")
+        self.assertEqual(ct, ResourceType.CVE)
+
+    def test_dfn_cert_adv(self):
+        ct = ResourceType.from_string("dfn_cert_adv")
+        self.assertEqual(ct, ResourceType.DFN_CERT_ADV)
+
+    def test_filter(self):
+        ct = ResourceType.from_string("filter")
+        self.assertEqual(ct, ResourceType.FILTER)
+
+    def test_group(self):
+        ct = ResourceType.from_string("group")
+        self.assertEqual(ct, ResourceType.GROUP)
+
+    def test_host(self):
+        ct = ResourceType.from_string("host")
+        self.assertEqual(ct, ResourceType.HOST)
+
+    def test_note(self):
+        ct = ResourceType.from_string("note")
+        self.assertEqual(ct, ResourceType.NOTE)
+
+    def test_nvt(self):
+        ct = ResourceType.from_string("nvt")
+        self.assertEqual(ct, ResourceType.NVT)
+
+    def test_os(self):
+        ct = ResourceType.from_string("os")
+        self.assertEqual(ct, ResourceType.OS)
+
+    def test_override(self):
+        ct = ResourceType.from_string("override")
+        self.assertEqual(ct, ResourceType.OVERRIDE)
+
+    def test_permission(self):
+        ct = ResourceType.from_string("permission")
+        self.assertEqual(ct, ResourceType.PERMISSION)
+
+    def test_port_list(self):
+        ct = ResourceType.from_string("port_list")
+        self.assertEqual(ct, ResourceType.PORT_LIST)
+
+    def test_report_format(self):
+        ct = ResourceType.from_string("report_format")
+        self.assertEqual(ct, ResourceType.REPORT_FORMAT)
+
+    def test_report(self):
+        ct = ResourceType.from_string("report")
+        self.assertEqual(ct, ResourceType.REPORT)
+
+    def test_result(self):
+        ct = ResourceType.from_string("result")
+        self.assertEqual(ct, ResourceType.RESULT)
+
+    def test_role(self):
+        ct = ResourceType.from_string("role")
+        self.assertEqual(ct, ResourceType.ROLE)
+
+    def test_scanner(self):
+        ct = ResourceType.from_string("scanner")
+        self.assertEqual(ct, ResourceType.SCANNER)
+
+    def test_schedule(self):
+        ct = ResourceType.from_string("schedule")
+        self.assertEqual(ct, ResourceType.SCHEDULE)
+
+    def test_target(self):
+        ct = ResourceType.from_string("target")
+        self.assertEqual(ct, ResourceType.TARGET)
+
+    def test_task(self):
+        ct = ResourceType.from_string("task")
+        self.assertEqual(ct, ResourceType.TASK)
+
+    def test_tls_certificate(self):
+        ct = ResourceType.from_string("tls_certificate")
+        self.assertEqual(ct, ResourceType.TLS_CERTIFICATE)
+
+    def test_user(self):
+        ct = ResourceType.from_string("user")
+        self.assertEqual(ct, ResourceType.USER)
+
+    def test_allresources(self):
+        with self.assertRaises(InvalidArgument):
+            ResourceType.from_string("allresources")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_scanner_type.py
+++ b/tests/protocols/gmpv225/enums/test_scanner_type.py
@@ -1,0 +1,66 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import ScannerType
+
+
+class GetScannerTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            ScannerType.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = ScannerType.from_string(None)
+        self.assertIsNone(ct)
+        ct = ScannerType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_openvas_scanner(self):
+        ct = ScannerType.from_string("2")
+        self.assertEqual(ct, ScannerType.OPENVAS_SCANNER_TYPE)
+
+        ct = ScannerType.from_string("openvas")
+        self.assertEqual(ct, ScannerType.OPENVAS_SCANNER_TYPE)
+
+    def test_cve_scanner(self):
+        ct = ScannerType.from_string("3")
+        self.assertEqual(ct, ScannerType.CVE_SCANNER_TYPE)
+
+        ct = ScannerType.from_string("cve")
+        self.assertEqual(ct, ScannerType.CVE_SCANNER_TYPE)
+
+    def test_gmp_scanner(self):
+        with self.assertRaises(InvalidArgument):
+            ScannerType.from_string("4")
+
+        with self.assertRaises(InvalidArgument):
+            ScannerType.from_string("gmp")
+
+    def test_greenbone_sensor_scanner(self):
+        ct = ScannerType.from_string("5")
+        self.assertEqual(ct, ScannerType.GREENBONE_SENSOR_SCANNER_TYPE)
+
+        ct = ScannerType.from_string("greenbone")
+        self.assertEqual(ct, ScannerType.GREENBONE_SENSOR_SCANNER_TYPE)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_severity_level.py
+++ b/tests/protocols/gmpv225/enums/test_severity_level.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import SeverityLevel
+
+
+class GetSeverityLevelFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            SeverityLevel.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = SeverityLevel.from_string(None)
+        self.assertIsNone(ct)
+        ct = SeverityLevel.from_string("")
+        self.assertIsNone(ct)
+
+    def test_high(self):
+        ct = SeverityLevel.from_string("High")
+        self.assertEqual(ct, SeverityLevel.HIGH)
+
+    def test_medium(self):
+        ct = SeverityLevel.from_string("Medium")
+        self.assertEqual(ct, SeverityLevel.MEDIUM)
+
+    def test_low(self):
+        ct = SeverityLevel.from_string("Low")
+        self.assertEqual(ct, SeverityLevel.LOW)
+
+    def test_log(self):
+        ct = SeverityLevel.from_string("Log")
+        self.assertEqual(ct, SeverityLevel.LOG)
+
+    def test_alarm(self):
+        ct = SeverityLevel.from_string("Alarm")
+        self.assertEqual(ct, SeverityLevel.ALARM)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/enums/test_snmp_algorithms.py
+++ b/tests/protocols/gmpv225/enums/test_snmp_algorithms.py
@@ -1,0 +1,62 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import SnmpAuthAlgorithm, SnmpPrivacyAlgorithm
+
+
+class GetSnmpAuthAlgorithmFromStringTestCase(unittest.TestCase):
+    def test_invalid_status(self):
+        with self.assertRaises(InvalidArgument):
+            SnmpAuthAlgorithm.from_string("foo")
+
+    def test_none_or_empty_type(self):
+        ts = SnmpAuthAlgorithm.from_string(None)
+        self.assertIsNone(ts)
+        ts = SnmpAuthAlgorithm.from_string("")
+        self.assertIsNone(ts)
+
+    def test_sha1(self):
+        ts = SnmpAuthAlgorithm.from_string("sha1")
+        self.assertEqual(ts, SnmpAuthAlgorithm.SHA1)
+
+    def test_md5(self):
+        ts = SnmpAuthAlgorithm.from_string("md5")
+        self.assertEqual(ts, SnmpAuthAlgorithm.MD5)
+
+
+class GetSnmpPrivacyAlgorithmFromStringTestCase(unittest.TestCase):
+    def test_invalid_status(self):
+        with self.assertRaises(InvalidArgument):
+            SnmpPrivacyAlgorithm.from_string("foo")
+
+    def test_none_or_empty_type(self):
+        ts = SnmpPrivacyAlgorithm.from_string(None)
+        self.assertIsNone(ts)
+        ts = SnmpPrivacyAlgorithm.from_string("")
+        self.assertIsNone(ts)
+
+    def test_aes(self):
+        ts = SnmpPrivacyAlgorithm.from_string("aes")
+        self.assertEqual(ts, SnmpPrivacyAlgorithm.AES)
+
+    def test_des(self):
+        ts = SnmpPrivacyAlgorithm.from_string("des")
+        self.assertEqual(ts, SnmpPrivacyAlgorithm.DES)

--- a/tests/protocols/gmpv225/enums/test_sort_order.py
+++ b/tests/protocols/gmpv225/enums/test_sort_order.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,19 +16,30 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
 import unittest
 
-from gvm.protocols.next import Gmp, Osp
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import SortOrder
 
 
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
+class GetSortOrderFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            SortOrder.from_string("foo")
 
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+    def test_none_or_empty(self):
+        ct = SortOrder.from_string(None)
+        self.assertIsNone(ct)
+        ct = SortOrder.from_string("")
+        self.assertIsNone(ct)
+
+    def test_ascending(self):
+        ct = SortOrder.from_string("ascending")
+        self.assertEqual(ct, SortOrder.ASCENDING)
+
+    def test_descending(self):
+        ct = SortOrder.from_string("descending")
+        self.assertEqual(ct, SortOrder.DESCENDING)
 
 
 if __name__ == "__main__":

--- a/tests/protocols/gmpv225/enums/test_ticket_status.py
+++ b/tests/protocols/gmpv225/enums/test_ticket_status.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import TicketStatus
+
+
+class GetTicketStatusFromStringTestCase(unittest.TestCase):
+    def test_invalid_status(self):
+        with self.assertRaises(InvalidArgument):
+            TicketStatus.from_string("foo")
+
+    def test_none_or_empty_type(self):
+        ts = TicketStatus.from_string(None)
+        self.assertIsNone(ts)
+        ts = TicketStatus.from_string("")
+        self.assertIsNone(ts)
+
+    def test_ticket_status_open(self):
+        ts = TicketStatus.from_string("open")
+        self.assertEqual(ts, TicketStatus.OPEN)
+
+    def test_ticket_status_fixed(self):
+        ts = TicketStatus.from_string("fixed")
+        self.assertEqual(ts, TicketStatus.FIXED)
+
+    def test_ticket_status_closed(self):
+        ts = TicketStatus.from_string("closed")
+        self.assertEqual(ts, TicketStatus.CLOSED)

--- a/tests/protocols/gmpv225/enums/test_user_auth_type.py
+++ b/tests/protocols/gmpv225/enums/test_user_auth_type.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from gvm.errors import InvalidArgument
+from gvm.protocols.gmpv225 import UserAuthType
+
+
+class GetUserAuthTypeFromStringTestCase(unittest.TestCase):
+    def test_invalid(self):
+        with self.assertRaises(InvalidArgument):
+            UserAuthType.from_string("foo")
+
+    def test_none_or_empty(self):
+        ct = UserAuthType.from_string(None)
+        self.assertIsNone(ct)
+        ct = UserAuthType.from_string("")
+        self.assertIsNone(ct)
+
+    def test_file(self):
+        ct = UserAuthType.from_string("file")
+        self.assertEqual(ct, UserAuthType.FILE)
+
+    def test_radius_connect(self):
+        ct = UserAuthType.from_string("radius_connect")
+        self.assertEqual(ct, UserAuthType.RADIUS_CONNECT)
+
+    def test_ldap_connect(self):
+        ct = UserAuthType.from_string("ldap_connect")
+        self.assertEqual(ct, UserAuthType.LDAP_CONNECT)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/protocols/gmpv225/system/__init__.py
+++ b/tests/protocols/gmpv225/system/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -15,21 +15,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
-
-
-if __name__ == "__main__":
-    unittest.main()

--- a/tests/protocols/gmpv225/system/test_aggregates.py
+++ b/tests/protocols/gmpv225/system/test_aggregates.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
+from ...gmpv208.system.aggregates import GmpGetAggregatesTestMixin
+from ...gmpv225 import Gmpv225TestCase
 
 
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
-
-
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225GetAggregatesTestCase(GmpGetAggregatesTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/system/test_authentication.py
+++ b/tests/protocols/gmpv225/system/test_authentication.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,23 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from ...gmpv208.system.authentication import (
+    GmpAuthenticateTestMixin,
+    GmpDescribeAuthTestMixin,
+    GmpModifyAuthTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225AuthenticateTestCase(GmpAuthenticateTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225ModifyAuthTestCase(GmpModifyAuthTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225DescribeAuthCommandTestCase(
+    GmpDescribeAuthTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/system/test_feed.py
+++ b/tests/protocols/gmpv225/system/test_feed.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
+from ...gmpv208.system.feed import GmpGetFeedsTestMixin, GmpGetFeedTestMixin
+from ...gmpv225 import Gmpv225TestCase
 
 
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+class Gmpv225GetFeedTestCase(GmpGetFeedTestMixin, Gmpv225TestCase):
+    pass
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225GetFeedsTestCase(GmpGetFeedsTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/system/test_help.py
+++ b/tests/protocols/gmpv225/system/test_help.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
+from ...gmpv208.system.help import GmpHelpTestMixin
+from ...gmpv225 import Gmpv225TestCase
 
 
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
-
-
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225HelpTestCase(GmpHelpTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/system/test_system_reports.py
+++ b/tests/protocols/gmpv225/system/test_system_reports.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,11 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
+from ...gmpv208.system.system_reports import GmpGetSystemReportsTestMixin
+from ...gmpv225 import Gmpv225TestCase
 
 
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
-
-
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225GetSystemReportsTestCase(
+    GmpGetSystemReportsTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/system/test_trashcan.py
+++ b/tests/protocols/gmpv225/system/test_trashcan.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,18 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from ...gmpv208.system.trashcan import (
+    GmpEmptyTrashcanTestMixin,
+    GmpRestoreFromTrashcanTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225EmptyTrashcanTestCase(GmpEmptyTrashcanTestMixin, Gmpv225TestCase):
+    pass
+
+
+class Gmpv225RestoreFromTrashcanTestCase(
+    GmpRestoreFromTrashcanTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/system/test_user_settings.py
+++ b/tests/protocols/gmpv225/system/test_user_settings.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,27 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+from ...gmpv208.system.user_settings import (
+    GmpGetUserSettingsTestMixin,
+    GmpGetUserSettingTestMixin,
+    GmpModifyUserSettingTestMixin,
+)
+from ...gmpv225 import Gmpv225TestCase
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225GetUserSettingTestCase(
+    GmpGetUserSettingTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225GetUserSettingsTestCase(
+    GmpGetUserSettingsTestMixin, Gmpv225TestCase
+):
+    pass
+
+
+class Gmpv225ModifyUserSettingTestCase(
+    GmpModifyUserSettingTestMixin, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/system/test_versions.py
+++ b/tests/protocols/gmpv225/system/test_versions.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,16 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
+from ...gmpv208.system.versions import GmpGetVersionTestCase
+from ...gmpv225 import Gmpv225TestCase
+from .versions import GmpGetProtocolVersionTestCase
 
 
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+class Gmpv225GetVersionCommandTestCase(GmpGetVersionTestCase, Gmpv225TestCase):
+    pass
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225GmpGetProtocolVersionTestCase(
+    GmpGetProtocolVersionTestCase, Gmpv225TestCase
+):
+    pass

--- a/tests/protocols/gmpv225/system/versions/__init__.py
+++ b/tests/protocols/gmpv225/system/versions/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,4 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
-
-
-if __name__ == "__main__":
-    unittest.main()
+from .test_get_protocol_version import GmpGetProtocolVersionTestCase

--- a/tests/protocols/gmpv225/system/versions/test_get_protocol_version.py
+++ b/tests/protocols/gmpv225/system/versions/test_get_protocol_version.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
 
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
-
-
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
-
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
-
-
-if __name__ == "__main__":
-    unittest.main()
+class GmpGetProtocolVersionTestCase:
+    def test_protocol_version(self):
+        self.assertEqual(self.gmp.get_protocol_version(), (22, 5))

--- a/tests/protocols/gmpv225/test_gmp_types.py
+++ b/tests/protocols/gmpv225/test_gmp_types.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from gvm.protocols.gmpv208.entities.hosts import HostsOrdering
+
+from . import Gmpv225TestCase
+
+
+class GmpWithStatementTestMixin:
+    def test_types(self):
+        with self.gmp:
+            # Test that the values are equal
+            self.assertEqual(
+                self.gmp.types.AlertEvent.TASK_RUN_STATUS_CHANGED.value,
+                "Task run status changed",
+            )
+            self.assertEqual(
+                self.gmp.types.PermissionSubjectType.USER.value, "user"
+            )
+            self.assertEqual(
+                self.gmp.types.HostsOrdering.RANDOM.value, "random"
+            )
+
+            # Test usability of from_string
+            self.assertEqual(
+                self.gmp.types.HostsOrdering.from_string("reverse"),
+                self.gmp.types.HostsOrdering.REVERSE,
+            )
+
+            # Test, that the Enum class types are equal
+            self.assertEqual(self.gmp.types.HostsOrdering, HostsOrdering)
+
+
+class Gmpv225WithStatementTestCase(GmpWithStatementTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/gmpv225/test_with_statement.py
+++ b/tests/protocols/gmpv225/test_with_statement.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2018-2022 Greenbone AG
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -16,20 +16,20 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=no-member
-
-import unittest
-
-from gvm.protocols.next import Gmp, Osp
+from . import Gmpv225TestCase
 
 
-class LatestProtocolsTestCase(unittest.TestCase):
-    def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
+class GmpWithStatementTestMixin:
+    def test_with_statement(self):
+        self.connection.connect.has_not_been_called()
+        self.connection.disconnect.has_not_been_called()
 
-    def test_osp_version(self):
-        self.assertEqual(Osp.get_protocol_version(), (1, 2))
+        with self.gmp:
+            pass
+
+        self.connection.connect.has_been_called()
+        self.connection.disconnect.has_been_called()
 
 
-if __name__ == "__main__":
-    unittest.main()
+class Gmpv225WithStatementTestCase(GmpWithStatementTestMixin, Gmpv225TestCase):
+    pass

--- a/tests/protocols/test_latest.py
+++ b/tests/protocols/test_latest.py
@@ -25,7 +25,7 @@ from gvm.protocols.latest import Gmp, Osp
 
 class LatestProtocolsTestCase(unittest.TestCase):
     def test_gmp_version(self):
-        self.assertEqual(Gmp.get_protocol_version(), (22, 4))
+        self.assertEqual(Gmp.get_protocol_version(), (22, 5))
 
     def test_osp_version(self):
         self.assertEqual(Osp.get_protocol_version(), (1, 2))


### PR DESCRIPTION
## What

Add GMP version 22.05

## Why

New GMP command get_resource_names is added to get names and IDs of resources of given type.

## References

GEA-407

## Checklist

- [X] Tests


