### PR TITLE
Doc: Update documentation to add GMP version 22.5

### DIFF
--- a/docs/api/gmpv225.rst
+++ b/docs/api/gmpv225.rst
@@ -1,9 +1,9 @@
-.. _gmpv224:
+.. _gmpv225:
 
-GMP v22.4
+GMP v22.5
 ^^^^^^^^^
 
-.. automodule:: gvm.protocols.gmpv224
+.. automodule:: gvm.protocols.gmpv225
 
 Enums
 -----
@@ -11,102 +11,86 @@ Enums
 .. autoclass:: AlertCondition
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: AlertEvent
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: AlertMethod
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: AliveTest
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: CredentialFormat
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: CredentialType
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: EntityType
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: FeedType
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: FilterType
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: HostsOrdering
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: HelpFormat
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: InfoType
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: PermissionSubjectType
     :members:
     :undoc-members:
-    :noindex:    
 
 .. autoclass:: PortRangeType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: ReportFormatType
     :members:
     :undoc-members:
-    :noindex:
+
+.. autoclass:: ResourceType
+    :members:
+    :undoc-members:
 
 .. autoclass:: ScannerType
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: SeverityLevel
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: SnmpAuthAlgorithm
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: SnmpPrivacyAlgorithm
     :members:
     :undoc-members:
-    :noindex:
 
 .. autoclass:: TicketStatus
     :members:
     :undoc-members:
-    :noindex:    
 
 Protocol
 --------

--- a/docs/api/protocols.rst
+++ b/docs/api/protocols.rst
@@ -11,6 +11,7 @@ Protocols
     gmpv208
     gmpv214
     gmpv224
+    gmpv225
     ospv1
 
 Dynamic

--- a/gvm/protocols/__init__.py
+++ b/gvm/protocols/__init__.py
@@ -19,7 +19,7 @@
 Package for supported Greenbone Protocol versions.
 
 Currently `GMP version 20.08`_, `GMP version 21.04`_
-`GMP version 22.04`, `GMP version 22.05`
+`GMP version 22.04`_, `GMP version 22.05`_
 and `OSP version 1`_ are supported.
 
 .. _GMP version 20.08:

--- a/gvm/protocols/gmpv225/entities/resourcenames.py
+++ b/gvm/protocols/gmpv225/entities/resourcenames.py
@@ -85,11 +85,11 @@ class ResourceNamesMixin:
 
         Arguments:
             resource_type: Type must be either ALERT, CERT_BUND_ADV,
-            CONFIG, CPE, CREDENTIAL, CVE, DFN_CERT_ADV, FILTER,
-            GROUP, HOST, NOTE, NVT, OS, OVERRIDE, PERMISSION,
-            PORT_LIST, REPORT_FORMAT, REPORT, RESULT, ROLE,
-            SCANNER, SCHEDULE, TARGET, TASK, TLS_CERTIFICATE
-            or USER
+                CONFIG, CPE, CREDENTIAL, CVE, DFN_CERT_ADV, FILTER,
+                GROUP, HOST, NOTE, NVT, OS, OVERRIDE, PERMISSION,
+                PORT_LIST, REPORT_FORMAT, REPORT, RESULT, ROLE,
+                SCANNER, SCHEDULE, TARGET, TASK, TLS_CERTIFICATE
+                or USER
             filter_string: Filter term to use for the query
 
         Returns:
@@ -124,11 +124,11 @@ class ResourceNamesMixin:
         Arguments:
             resource_id: ID of an existing resource
             resource_type: Type must be either ALERT, CERT_BUND_ADV,
-            CONFIG, CPE, CREDENTIAL, CVE, DFN_CERT_ADV, FILTER,
-            GROUP, HOST, NOTE, NVT, OS, OVERRIDE, PERMISSION,
-            PORT_LIST, REPORT_FORMAT, REPORT, RESULT, ROLE,
-            SCANNER, SCHEDULE, TARGET, TASK, TLS_CERTIFICATE
-            or USER
+                CONFIG, CPE, CREDENTIAL, CVE, DFN_CERT_ADV, FILTER,
+                GROUP, HOST, NOTE, NVT, OS, OVERRIDE, PERMISSION,
+                PORT_LIST, REPORT_FORMAT, REPORT, RESULT, ROLE,
+                SCANNER, SCHEDULE, TARGET, TASK, TLS_CERTIFICATE
+                or USER
 
         Returns:
             The response. See :py:meth:`send_command` for details.

--- a/gvm/protocols/latest.py
+++ b/gvm/protocols/latest.py
@@ -27,7 +27,7 @@ For details about the possible supported protocol versions please take a look at
 :py:mod:`gvm.protocols`.
 
 Exports:
-  - :py:class:`gvm.protocols.gmpv224.Gmp`
+  - :py:class:`gvm.protocols.gmpv225.Gmp`
   - :py:class:`gvm.protocols.ospv1.Osp`
 
 .. _Greenbone Management Protocol:


### PR DESCRIPTION
## What
Update documentation to add GMP version 22.5

## Why
Documentation was missing.

## References
GEA-407


