### PR TITLE
Fix: Enable "security-and-quality" queries for CodeQL

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -33,6 +33,7 @@ jobs:
         uses: github/codeql-action/init@v2
         with:
           languages: ${{ matrix.language }}
+          queries: security-and-quality
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
## What
Enable "security-and-quality" queries for CodeQL

## Why
Should have been enabled according to our GitHub policies but was not.

## References
GEA-422


