### PR TITLE
Fix various CodeQL alerts

### DIFF
--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -313,9 +313,7 @@ class SSHConnection(GvmConnection):
                         save = input()
                 break
             elif add == "no":
-                sys.exit(
-                    "User denied key. Host key verification failed."
-                )
+                sys.exit("User denied key. Host key verification failed.")
             else:
                 print("Please type 'yes' or 'no': ", end="")
                 add = input()

--- a/gvm/connections.py
+++ b/gvm/connections.py
@@ -313,7 +313,7 @@ class SSHConnection(GvmConnection):
                         save = input()
                 break
             elif add == "no":
-                return sys.exit(
+                sys.exit(
                     "User denied key. Host key verification failed."
                 )
             else:

--- a/gvm/errors.py
+++ b/gvm/errors.py
@@ -150,7 +150,7 @@ class InvalidArgumentType(GvmError):
         *,
         function: Optional[str] = None,
     ):
-        # pylint: disable=super-init-not-called
+        super().__init__(None)
         self.argument = argument
         self.function = function
         self.arg_type = arg_type

--- a/gvm/protocols/gmpv208/entities/filter.py
+++ b/gvm/protocols/gmpv208/entities/filter.py
@@ -131,7 +131,7 @@ class FiltersMixin:
             )
 
         cmd = XmlCommand("create_filter")
-        _xmlname = cmd.add_element("name", name)
+        cmd.add_element("name", name)
 
         if comment:
             cmd.add_element("comment", comment)

--- a/gvm/protocols/gmpv208/entities/tickets.py
+++ b/gvm/protocols/gmpv208/entities/tickets.py
@@ -66,7 +66,7 @@ class TicketsMixin:
 
         cmd = XmlCommand("create_ticket")
 
-        _copy = cmd.add_element("copy", ticket_id)
+        cmd.add_element("copy", ticket_id)
 
         return self._send_xml_command(cmd)
 
@@ -114,7 +114,7 @@ class TicketsMixin:
         _user = _assigned.add_element("user")
         _user.set_attribute("id", assigned_to_user_id)
 
-        _note = cmd.add_element("open_note", note)
+        cmd.add_element("open_note", note)
 
         if comment:
             cmd.add_element("comment", comment)

--- a/gvm/protocols/ospv1.py
+++ b/gvm/protocols/ospv1.py
@@ -63,9 +63,7 @@ def create_vt_selection_element(_xmlvtselection, vt_selection):
                     _xmlvt.add_element("vt_value", value, attrs={"id": key})
         elif vt_id == "vt_groups" and isinstance(vt_values, list):
             for group in vt_values:
-                _xmlvtselection.add_element(
-                    "vt_group", attrs={"filter": group}
-                )
+                _xmlvtselection.add_element("vt_group", attrs={"filter": group})
         else:
             raise InvalidArgument(
                 f"It was not possible to add {vt_id} to the VTs selection."

--- a/gvm/protocols/ospv1.py
+++ b/gvm/protocols/ospv1.py
@@ -63,7 +63,7 @@ def create_vt_selection_element(_xmlvtselection, vt_selection):
                     _xmlvt.add_element("vt_value", value, attrs={"id": key})
         elif vt_id == "vt_groups" and isinstance(vt_values, list):
             for group in vt_values:
-                _xmlvt = _xmlvtselection.add_element(
+                _xmlvtselection.add_element(
                     "vt_group", attrs={"filter": group}
                 )
         else:
@@ -252,9 +252,8 @@ class Osp(GvmProtocol):
                 _xmltarget.add_element("hosts", hosts)
                 _xmltarget.add_element("ports", ports)
                 if credentials:
-                    _xmlcredentials = _xmltarget.add_element("credentials")
                     _xmlcredentials = create_credentials_element(
-                        _xmlcredentials, credentials
+                        _xmltarget.add_element("credentials"), credentials
                     )
         # Check target as attribute for legacy mode compatibility. Deprecated.
         elif target:
@@ -267,9 +266,8 @@ class Osp(GvmProtocol):
             )
 
         if vt_selection:
-            _xmlvtselection = cmd.add_element("vt_selection")
             _xmlvtselection = create_vt_selection_element(
-                _xmlvtselection, vt_selection
+                cmd.add_element("vt_selection"), vt_selection
             )
 
         return self._send_xml_command(cmd)

--- a/gvm/utils.py
+++ b/gvm/utils.py
@@ -71,7 +71,6 @@ def check_command_status(xml: str) -> bool:
         logger.error("etree.XML(xml): %s", e)
         return False
 
-    return False
 
 
 def to_dotted_types_dict(types: List) -> TypesDict:

--- a/gvm/utils.py
+++ b/gvm/utils.py
@@ -72,7 +72,6 @@ def check_command_status(xml: str) -> bool:
         return False
 
 
-
 def to_dotted_types_dict(types: List) -> TypesDict:
     """Create a dictionary accessible via dot notation"""
     dic = {}

--- a/gvm/utils.py
+++ b/gvm/utils.py
@@ -66,9 +66,12 @@ def check_command_status(xml: str) -> bool:
     except KeyError:
         print(logger)
         logger.error("Not received an status code within the response.")
+        return False
     except etree.Error as e:
         logger.error("etree.XML(xml): %s", e)
         return False
+
+    return False
 
 
 def to_dotted_types_dict(types: List) -> TypesDict:


### PR DESCRIPTION
## What

- The check_command_status function will now always explicitly return
False unless the check succeeds while the non-None return from
_ssh_authentication_input_loop has been removed.
- Some unused local variables holding the return values from add_element
calls are removed.
- The class InvalidArgumentType now explicitly calls the superclass
initializer, making it more explict that the message is set to None.

## Why

This addresses various CodeQL alerts.

## References

GEA-421

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


