### PR TITLE
Change: Use trusted publisher upload for PyPI

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -6,5 +6,12 @@ on:
 
 jobs:
   deploy:
-    uses: greenbone/workflows/.github/workflows/deploy-pypi.yml@main
-    secrets: inherit
+    permissions:
+      id-token: write
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/python-gvm/
+    steps:
+      - name: Build and publish to PyPI
+        uses: greenbone/actions/pypi-upload@v3


### PR DESCRIPTION
## What

Use trusted publisher upload for PyPI

## Why
[Trusted publisher](https://docs.pypi.org/trusted-publishers/) improves the security of the deployment

## References

DEVOPS-936