### PR TITLE
Allow to use ignore_pagination for get_tasks

### DIFF
--- a/gvm/protocols/gmp/_gmp224.py
+++ b/gvm/protocols/gmp/_gmp224.py
@@ -3805,6 +3805,7 @@ class GMPv224(GvmProtocol[T]):
         trash: Optional[bool] = None,
         details: Optional[bool] = None,
         schedules_only: Optional[bool] = None,
+        ignore_pagination: Optional[bool] = None,
     ) -> T:
         """Request a list of tasks
 
@@ -3815,6 +3816,8 @@ class GMPv224(GvmProtocol[T]):
             details: Whether to include full task details
             schedules_only: Whether to only include id, name and schedule
                 details
+            ignore_pagination: Whether to ignore pagination settings (filter
+                terms "first" and "rows"). Default is False.
         """
         return self._send_and_transform_command(
             Tasks.get_tasks(
@@ -3823,6 +3826,7 @@ class GMPv224(GvmProtocol[T]):
                 trash=trash,
                 details=details,
                 schedules_only=schedules_only,
+                ignore_pagination=ignore_pagination,
             )
         )
 

--- a/gvm/protocols/gmp/requests/v224/_tasks.py
+++ b/gvm/protocols/gmp/requests/v224/_tasks.py
@@ -200,6 +200,7 @@ class Tasks:
         trash: Optional[bool] = None,
         details: Optional[bool] = None,
         schedules_only: Optional[bool] = None,
+        ignore_pagination: Optional[bool] = None,
     ) -> Request:
         """Request a list of tasks
 
@@ -210,6 +211,8 @@ class Tasks:
             details: Whether to include full task details
             schedules_only: Whether to only include id, name and schedule
                 details
+            ignore_pagination: Whether to ignore pagination settings (filter
+                terms "first" and "rows"). Default is False.
         """
         cmd = XmlCommand("get_tasks")
         cmd.set_attribute("usage_type", "scan")
@@ -224,6 +227,9 @@ class Tasks:
 
         if schedules_only is not None:
             cmd.set_attribute("schedules_only", to_bool(schedules_only))
+
+        if ignore_pagination is not None:
+            cmd.set_attribute("ignore_pagination", to_bool(ignore_pagination))
 
         return cmd
 

--- a/tests/protocols/gmp/requests/v224/test_tasks.py
+++ b/tests/protocols/gmp/requests/v224/test_tasks.py
@@ -453,6 +453,19 @@ class TasksTestCase(unittest.TestCase):
             b'<get_tasks usage_type="scan" schedules_only="0"/>',
         )
 
+    def test_get_tasks_with_ignore_pagination(self):
+        request = Tasks().get_tasks(ignore_pagination=True)
+        self.assertEqual(
+            bytes(request),
+            b'<get_tasks usage_type="scan" ignore_pagination="1"/>',
+        )
+
+        request = Tasks().get_tasks(ignore_pagination=False)
+        self.assertEqual(
+            bytes(request),
+            b'<get_tasks usage_type="scan" ignore_pagination="0"/>',
+        )
+
     def test_get_task(self):
         request = Tasks().get_task("task_id")
         self.assertEqual(

--- a/tests/protocols/gmpv224/entities/tasks/test_get_tasks.py
+++ b/tests/protocols/gmpv224/entities/tasks/test_get_tasks.py
@@ -53,3 +53,16 @@ class GmpGetTasksTestMixin:
         self.connection.send.has_been_called_with(
             b'<get_tasks usage_type="scan" schedules_only="1"/>'
         )
+
+    def test_get_tasks_with_ignore_pagination(self):
+        self.gmp.get_tasks(ignore_pagination=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_tasks usage_type="scan" ignore_pagination="1"/>'
+        )
+
+        self.gmp.get_tasks(ignore_pagination=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_tasks usage_type="scan" ignore_pagination="0"/>'
+        )


### PR DESCRIPTION


## What

Allow to use ignore_pagination for get_tasks

## Why

GMP has the ignore_pagination attribute for getting a list of tasks. Add the argument to python-gvm too.

## References

#1138
## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


