### PR TITLE
Adjust transform classes for bytes based protocol

### DIFF
--- a/gvm/transforms.py
+++ b/gvm/transforms.py
@@ -7,6 +7,8 @@ Module for transforming responses
 """
 from lxml import etree
 
+from gvm.protocols.core import Response
+
 from .errors import GvmError, GvmResponseError, GvmServerError
 from .xml import Element, create_parser
 
@@ -19,10 +21,10 @@ class EtreeTransform:
     def __init__(self):
         self._parser = create_parser()
 
-    def _convert_response(self, response: str) -> Element:
-        return etree.XML(response, parser=self._parser)
+    def _convert_response(self, response: Response) -> Element:
+        return etree.XML(bytes(response), parser=self._parser)
 
-    def __call__(self, response: str) -> Element:
+    def __call__(self, response: Response) -> Element:
         return self._convert_response(response)
 
 
@@ -46,7 +48,7 @@ class CheckCommandTransform(EtreeTransform):
     response was an error response
     """
 
-    def __call__(self, response: str) -> str:  # type: ignore[override]
+    def __call__(self, response: Response) -> Response:  # type: ignore[override]
         root = self._convert_response(response)
 
         check_command_status(root)
@@ -60,7 +62,7 @@ class EtreeCheckCommandTransform(EtreeTransform):
     response was an error response
     """
 
-    def __call__(self, response: str) -> Element:
+    def __call__(self, response: Response) -> Element:
         root = self._convert_response(response)
 
         check_command_status(root)

--- a/tests/transforms/test_check_command_transform.py
+++ b/tests/transforms/test_check_command_transform.py
@@ -16,7 +16,7 @@ class CheckCommandTransformTestCase(unittest.TestCase):
         transform = CheckCommandTransform()
 
         with self.assertRaises(GvmError):
-            transform("<foo/>")
+            transform(b"<foo/>")
 
     def test_no_success_300status_transform(self):
         transform = CheckCommandTransform()
@@ -25,7 +25,7 @@ class CheckCommandTransformTestCase(unittest.TestCase):
         root.set("status", "300")
         root.set("status_text", "Foo error")
 
-        response = etree.tostring(root).decode("utf-8")
+        response = etree.tostring(root)
 
         with self.assertRaises(GvmError):
             transform(response)
@@ -37,7 +37,7 @@ class CheckCommandTransformTestCase(unittest.TestCase):
         root.set("status", "400")
         root.set("status_text", "Foo error")
 
-        response = etree.tostring(root).decode("utf-8")
+        response = etree.tostring(root)
 
         with self.assertRaises(GvmResponseError):
             transform(response)
@@ -49,7 +49,7 @@ class CheckCommandTransformTestCase(unittest.TestCase):
         root.set("status", "500")
         root.set("status_text", "Foo error")
 
-        response = etree.tostring(root).decode("utf-8")
+        response = etree.tostring(root)
 
         with self.assertRaises(GvmServerError):
             transform(response)
@@ -60,6 +60,6 @@ class CheckCommandTransformTestCase(unittest.TestCase):
         root = etree.Element("foo_response")
         root.set("status", "200")
 
-        response = etree.tostring(root).decode("utf-8")
+        response = etree.tostring(root)
 
-        self.assertEqual(transform(response), '<foo_response status="200"/>')
+        self.assertEqual(transform(response), b'<foo_response status="200"/>')

--- a/tests/transforms/test_etree_check_command_transform.py
+++ b/tests/transforms/test_etree_check_command_transform.py
@@ -16,7 +16,7 @@ class EtreeCheckCommandTransformTestCase(unittest.TestCase):
         transform = EtreeCheckCommandTransform()
 
         with self.assertRaises(GvmError):
-            transform("<foo/>")
+            transform(b"<foo/>")
 
     def test_no_success_status_transform(self):
         transform = EtreeCheckCommandTransform()
@@ -25,7 +25,7 @@ class EtreeCheckCommandTransformTestCase(unittest.TestCase):
         root.set("status", "400")
         root.set("status_text", "Foo error")
 
-        response = etree.tostring(root).decode("utf-8")
+        response = etree.tostring(root)
 
         with self.assertRaises(GvmError):
             transform(response)
@@ -36,7 +36,7 @@ class EtreeCheckCommandTransformTestCase(unittest.TestCase):
         root = etree.Element("foo_response")
         root.set("status", "200")
 
-        response = etree.tostring(root).decode("utf-8")
+        response = etree.tostring(root)
 
         result = transform(response)
 

--- a/tests/transforms/test_etree_transform.py
+++ b/tests/transforms/test_etree_transform.py
@@ -13,13 +13,13 @@ from gvm.transforms import EtreeTransform
 class EtreeTransformTestCase(unittest.TestCase):
     def test_transform_response(self):
         transform = EtreeTransform()
-        result = transform("<foo/>")
+        result = transform(b"<foo/>")
 
         self.assertTrue(etree.iselement(result))
 
     def test_transform_more_complex_response(self):
         transform = EtreeTransform()
-        result = transform('<foo id="bar"><lorem/><ipsum/></foo>')
+        result = transform(b'<foo id="bar"><lorem/><ipsum/></foo>')
 
         self.assertTrue(etree.iselement(result))
         self.assertEqual(result.tag, "foo")


### PR DESCRIPTION


## What

Adjust transform classes for bytes based protocol

## Why

For the protocol implementation bytes are passed in the form of Responses to the transform callables. Therefore adjust the Transform classes to handle bytes now.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


