### PR TITLE
Allow to auto-generate password and ssh-key for credentials

### DIFF
--- a/gvm/protocols/gmp/requests/v224/_credentials.py
+++ b/gvm/protocols/gmp/requests/v224/_credentials.py
@@ -194,6 +194,26 @@ class Credentials:
                     credential_type=CredentialType.PASSWORD_ONLY,
                     password='foo',
                 )
+
+            Creating an auto-generated password
+
+            .. code-block:: python
+
+                request = Credentials.create_credential(
+                    name='UP Credential',
+                    credential_type=CredentialType.USERNAME_PASSWORD,
+                    login='foo',
+                )
+
+            Creating an auto-generated SSH-Key credential
+
+            .. code-block:: python
+
+                request = Credentials.create_credential(
+                    name='USK Credential',
+                    credential_type=CredentialType.USERNAME_SSH_KEY,
+                    login='foo',
+                )
         """
         if not name:
             raise RequiredArgument(
@@ -256,7 +276,10 @@ class Credentials:
         ) and password:
             cmd.add_element("password", password)
 
-        if credential_type == CredentialType.USERNAME_SSH_KEY:
+        if (
+            credential_type == CredentialType.USERNAME_SSH_KEY
+            and private_key is not None
+        ):
             if not private_key:
                 raise RequiredArgument(
                     function=cls.create_credential.__name__,

--- a/tests/protocols/gmp/requests/v224/test_credentials.py
+++ b/tests/protocols/gmp/requests/v224/test_credentials.py
@@ -68,6 +68,21 @@ class CredentialsTestCase(unittest.TestCase):
             b"</create_credential>",
         )
 
+    def test_create_credential_username_password_auto_generate_password(self):
+        request = Credentials.create_credential(
+            "name",
+            CredentialType.USERNAME_PASSWORD,
+            login="username",
+        )
+        self.assertEqual(
+            bytes(request),
+            b"<create_credential>"
+            b"<name>name</name>"
+            b"<type>up</type>"
+            b"<login>username</login>"
+            b"</create_credential>",
+        )
+
     def test_create_username_password_credential_with_allow_insecure(self):
         request = Credentials.create_credential(
             "name",
@@ -207,12 +222,23 @@ class CredentialsTestCase(unittest.TestCase):
             b"</create_credential>",
         )
 
-    def test_create_credential_username_ssh_key_missing_private_key(self):
-        with self.assertRaises(RequiredArgument):
-            Credentials.create_credential(
-                "name", CredentialType.USERNAME_SSH_KEY, login="username"
-            )
+    def test_create_credential_username_ssh_key_auto_generate_key(self):
+        request = Credentials.create_credential(
+            "name",
+            CredentialType.USERNAME_SSH_KEY,
+            login="username",
+        )
 
+        self.assertEqual(
+            bytes(request),
+            b"<create_credential>"
+            b"<name>name</name>"
+            b"<type>usk</type>"
+            b"<login>username</login>"
+            b"</create_credential>",
+        )
+
+    def test_create_credential_username_ssh_key_missing_private_key(self):
         with self.assertRaises(RequiredArgument):
             Credentials.create_credential(
                 "name",

--- a/tests/protocols/gmpv224/entities/credentials/test_create_credential.py
+++ b/tests/protocols/gmpv224/entities/credentials/test_create_credential.py
@@ -87,6 +87,21 @@ class GmpCreateCredentialTestMixin:
             b"</create_credential>"
         )
 
+    def test_create_up_credential_auto_generate_password(self):
+        self.gmp.create_credential(
+            name="foo",
+            credential_type=CredentialType.USERNAME_PASSWORD,
+            login="Max",
+        )
+
+        self.connection.send.has_been_called_with(
+            b"<create_credential>"
+            b"<name>foo</name>"
+            b"<type>up</type>"
+            b"<login>Max</login>"
+            b"</create_credential>"
+        )
+
     def test_create_cc_credential_missing_certificate(self):
         with self.assertRaises(RequiredArgument):
             self.gmp.create_credential(
@@ -133,6 +148,7 @@ class GmpCreateCredentialTestMixin:
                 name="foo",
                 credential_type=CredentialType.USERNAME_SSH_KEY,
                 login="foo",
+                private_key="",
             )
 
     def test_create_usk_credential_missing_login(self):
@@ -180,6 +196,21 @@ class GmpCreateCredentialTestMixin:
             b"<private>123456</private>"
             b"<phrase>abcdef</phrase>"
             b"</key>"
+            b"</create_credential>"
+        )
+
+    def test_create_usk_credential_auto_generate_ssh_key(self):
+        self.gmp.create_credential(
+            name="foo",
+            credential_type=CredentialType.USERNAME_SSH_KEY,
+            login="foo",
+        )
+
+        self.connection.send.has_been_called_with(
+            b"<create_credential>"
+            b"<name>foo</name>"
+            b"<type>usk</type>"
+            b"<login>foo</login>"
             b"</create_credential>"
         )
 


### PR DESCRIPTION


## What
Allow to auto-generate password and ssh-key for credentials

## Why

Support auto-generating the password for a username+password credential and the ssh-key for a username+ssh-key credential. This is already supported by GMP since early versions but wasn't implemented in python-gvm.
## References

DOS-209

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


