### PR TITLE
Update README for usage of GMP < 22.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,8 +41,15 @@ Please consider to always use the **newest** version of `gvm-tools` and `python-
 We frequently update this projects to add features and keep them free from bugs.
 This is why installing `python-gvm` using pip is recommended.
 
-**To use `python-gvm` with an old GMP version (7, 8, 9) you must use a release version**
-**that is `<21.05`. In the `21.05` release the support of these versions have been dropped.**
+> [!IMPORTANT]
+> To use `python-gvm` with GMP version of 7, 8 or 9 you must use a release version
+> that is `<21.5`. In the `21.5` release the support of these versions has been
+> dropped.
+
+> [!IMPORTANT]
+> To use `python-gvm` with  GMP version 20.8 or 21.4 you must use a release version
+> that is `<24.6`. In the `24.6` release the support of these versions has been
+> dropped.
 
 ### Requirements
 


### PR DESCRIPTION


## What

Update README for usage of GMP < 22.4

## Why

GMP < 22.4 can only be used with a python-gvm release < 24.6


