### PR TITLE
Change: Drop typing_extensions dependency.

### DIFF
--- a/gvm/_enum.py
+++ b/gvm/_enum.py
@@ -4,11 +4,11 @@
 #
 
 from enum import Enum as PythonEnum
-from typing import Any, Optional, TypeVar
+from typing import Any, Optional, Type, TypeVar
 
 from gvm.errors import InvalidArgument
 
-Self = TypeVar("Self", bound="PythonEnum")
+Self = TypeVar("Self", bound="Enum")
 
 
 class Enum(PythonEnum):
@@ -17,14 +17,14 @@ class Enum(PythonEnum):
     """
 
     @classmethod
-    def _missing_(cls, value: Any) -> Optional[Self]:
+    def _missing_(cls: Type[Self], value: Any) -> Optional[Self]:
         if isinstance(value, PythonEnum):
             return cls.from_string(value.name)
         return cls.from_string(str(value) if value else None)
 
     @classmethod
     def from_string(
-        cls,
+        cls: Type[Self],
         value: Optional[str],
     ) -> Optional[Self]:
         """

--- a/gvm/_enum.py
+++ b/gvm/_enum.py
@@ -4,11 +4,11 @@
 #
 
 from enum import Enum as PythonEnum
-from typing import Any, Optional
-
-from typing_extensions import Self
+from typing import Any, Optional, TypeVar
 
 from gvm.errors import InvalidArgument
+
+Self = TypeVar("Self", bound="PythonEnum")
 
 
 class Enum(PythonEnum):

--- a/gvm/protocols/_protocol.py
+++ b/gvm/protocols/_protocol.py
@@ -44,7 +44,7 @@ class GvmProtocol(Generic[T]):
 
         self._transform_callable = transform
 
-    def __enter__(self) -> Self:
+    def __enter__(self: Self) -> Self:
         self.connect()
         return self
 

--- a/gvm/protocols/_protocol.py
+++ b/gvm/protocols/_protocol.py
@@ -3,15 +3,14 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from types import TracebackType
-from typing import Callable, Generic, Optional, Type
-
-from typing_extensions import Self, TypeVar
+from typing import Callable, Generic, Optional, Type, TypeVar
 
 from gvm.connections import GvmConnection
 
 from .core import Connection, Request, Response
 
-T = TypeVar("T", default=str)
+T = TypeVar("T")
+Self = TypeVar("Self", bound="GvmProtocol")
 
 
 def str_transform(response: Response) -> str:

--- a/gvm/protocols/core/_response.py
+++ b/gvm/protocols/core/_response.py
@@ -3,9 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from functools import cached_property
-from typing import Optional
-
-from typing_extensions import Self
+from typing import Optional, TypeVar
 
 from gvm.errors import GvmError
 from gvm.xml import Element, parse_xml
@@ -24,6 +22,9 @@ class StatusError(GvmError):
         super().__init__(message, *args)
         self.response = response
         self.request = response.request
+
+
+Self = TypeVar("Self", bound="Response")
 
 
 class Response:

--- a/gvm/protocols/core/_response.py
+++ b/gvm/protocols/core/_response.py
@@ -95,7 +95,7 @@ class Response:
         status = self.status_code
         return status is not None and 200 <= status <= 299
 
-    def raise_for_status(self) -> Self:
+    def raise_for_status(self: Self) -> Self:
         if self.is_success:
             return self
         raise StatusError(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1585,4 +1585,4 @@ test = ["big-O", "importlib-resources", "jaraco.functools", "jaraco.itertools", 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "6b87db303635388552fb0d240fcda7d8e998577edd951f068a061132cde19119"
+content-hash = "ab8577ef4c37473bc1c77282d52f779c8a049283eaf2236b97acac81e3c27581"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ packages = [{ include = "gvm" }, { include = "tests", format = "sdist" }]
 python = "^3.9"
 paramiko = ">=2.7.1"
 lxml = ">=4.5.0"
-typing-extensions = ">=4.9.0"
 
 [tool.poetry.group.dev.dependencies]
 coverage = ">=7.2"


### PR DESCRIPTION
## What
Drop typing_extensions dependency.

## Why
typing_extensions was needed for using the Self component (which was introduced in version 4.0.0) however the versions shipped with Debian are older.

typing_extensions is dropped and the typing library is used instead.

## References
GEA-638


