### PR TITLE
Fix: Update outdated settings in pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ exclude = '''
 [tool.ruff]
 line-length = 80
 target-version = "py311"
+
+[tool.ruff.lint]
 extend-select = ["I", "PLE", "PLW"]
 
 [tool.autohooks]


### PR DESCRIPTION
## What

Adjust the settings for ruff in the pyproject.toml,  Please update the following options in `pyproject.toml`:

    'extend-select' -> 'lint.extend-select'
    'ignore' -> 'lint.ignore'
    'per-file-ignores' -> 'lint.per-file-ignores'}}


## Why

.. to prevent the printing of:
 {{warning: The top-level linter settings are deprecated in favour of their counterparts in the `lint` section.

## References

[DEVOPS-1116](https://jira.greenbone.net/browse/DEVOPS-1116)
