### PR TITLE
Add: New openvasd scanner type and relay fields

### DIFF
--- a/gvm/protocols/gmp/_gmp226.py
+++ b/gvm/protocols/gmp/_gmp226.py
@@ -21,6 +21,8 @@ from .requests.v226 import (
     Reports,
     ResourceNames,
     ResourceType,
+    Scanners,
+    ScannerType,
 )
 
 
@@ -445,4 +447,157 @@ class GMPv226(GMPv225[T]):
             ReportConfigs.modify_report_config(
                 report_config_id, name=name, comment=comment, params=params
             )
+        )
+
+    def create_scanner(
+        self,
+        name: str,
+        host: str,
+        port: Union[str, int],
+        scanner_type: ScannerType,
+        credential_id: str,
+        *,
+        ca_pub: Optional[str] = None,
+        comment: Optional[str] = None,
+        relay_host: Optional[str] = None,
+        relay_port: Optional[Union[str, int]] = None,
+    ) -> T:
+        """Create a new scanner
+
+        Args:
+            name: Name of the new scanner
+            host: Hostname or IP address of the scanner
+            port: Port of the scanner
+            scanner_type: Type of the scanner
+            credential_id: UUID of client certificate credential for the
+                scanner
+            ca_pub: Certificate of CA to verify scanner certificate
+            comment: Comment for the scanner
+            relay_host: Hostname or IP address of the scanner relay
+            relay_port: Port of the scanner relay
+        """
+        return self._send_request_and_transform_response(
+            Scanners.create_scanner(
+                name,
+                host,
+                port,
+                scanner_type,
+                credential_id,
+                ca_pub=ca_pub,
+                comment=comment,
+                relay_host=relay_host,
+                relay_port=relay_port,
+            )
+        )
+
+    def modify_scanner(
+        self,
+        scanner_id: EntityID,
+        *,
+        name: Optional[str] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        scanner_type: Optional[ScannerType] = None,
+        credential_id: Optional[EntityID] = None,
+        ca_pub: Optional[str] = None,
+        comment: Optional[str] = None,
+        relay_host: Optional[str] = None,
+        relay_port: Optional[Union[str, int]] = None,
+    ) -> T:
+        """Modify an existing scanner
+
+        Args:
+            scanner_id: UUID of the scanner to modify
+            name: New name of the scanner
+            host: New hostname or IP address of the scanner
+            port: New port of the scanner
+            scanner_type: New type of the scanner
+            credential_id: New UUID of client certificate credential for the
+                scanner
+            ca_pub: New certificate of CA to verify scanner certificate
+            comment: New comment for the scanner
+            relay_host: Hostname or IP address of the scanner relay
+            relay_port: Port of the scanner relay
+        """
+        return self._send_request_and_transform_response(
+            Scanners.modify_scanner(
+                scanner_id,
+                name=name,
+                host=host,
+                port=port,
+                scanner_type=scanner_type,
+                credential_id=credential_id,
+                ca_pub=ca_pub,
+                comment=comment,
+                relay_host=relay_host,
+                relay_port=relay_port,
+            )
+        )
+
+    def get_scanners(
+        self,
+        *,
+        filter_string: Optional[str] = None,
+        filter_id: Optional[EntityID] = None,
+        trash: Optional[bool] = None,
+        details: Optional[bool] = None,
+    ) -> T:
+        """Request a list of scanners
+
+        Args:
+            filter_string: Filter term to use for the query
+            filter_id: UUID of an existing filter to use for the query
+            trash: Whether to get the trashcan scanners instead
+            details: Whether to include extra details like tasks using this
+                scanner
+        """
+        return self._send_request_and_transform_response(
+            Scanners.get_scanners(
+                filter_string=filter_string,
+                filter_id=filter_id,
+                trash=trash,
+                details=details,
+            )
+        )
+
+    def get_scanner(self, scanner_id: EntityID) -> T:
+        """Request a single scanner
+
+        Args:
+            scanner_id: UUID of an existing scanner
+        """
+        return self._send_request_and_transform_response(
+            Scanners.get_scanner(scanner_id)
+        )
+
+    def verify_scanner(self, scanner_id: EntityID) -> T:
+        """Verify an existing scanner
+
+        Args:
+            scanner_id: UUID of an existing scanner
+        """
+        return self._send_request_and_transform_response(
+            Scanners.verify_scanner(scanner_id)
+        )
+
+    def clone_scanner(self, scanner_id: EntityID) -> T:
+        """Clone an existing scanner
+
+        Args:
+            scanner_id: UUID of an existing scanner
+        """
+        return self._send_request_and_transform_response(
+            Scanners.clone_scanner(scanner_id)
+        )
+
+    def delete_scanner(
+        self, scanner_id: EntityID, ultimate: Optional[bool] = False
+    ) -> T:
+        """Delete an existing scanner
+
+        Args:
+            scanner_id: UUID of an existing scanner
+        """
+        return self._send_request_and_transform_response(
+            Scanners.delete_scanner(scanner_id, ultimate=ultimate)
         )

--- a/gvm/protocols/gmp/requests/v226/__init__.py
+++ b/gvm/protocols/gmp/requests/v226/__init__.py
@@ -48,8 +48,6 @@ from ..v225 import (
     Results,
     Roles,
     ScanConfigs,
-    Scanners,
-    ScannerType,
     Schedules,
     SecInfo,
     Severity,
@@ -71,6 +69,7 @@ from ..v225 import (
 )
 from ._audit_reports import AuditReports
 from ._filters import Filters, FilterType
+from ._scanners import Scanners, ScannerType
 from ._report_configs import ReportConfigParameter, ReportConfigs
 from ._reports import Reports
 from ._resource_names import ResourceNames, ResourceType

--- a/gvm/protocols/gmp/requests/v226/_scanners.py
+++ b/gvm/protocols/gmp/requests/v226/_scanners.py
@@ -1,0 +1,326 @@
+# SPDX-FileCopyrightText: 2021-2025 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from typing import Optional, Union
+
+from gvm._enum import Enum
+from gvm.errors import InvalidArgument, RequiredArgument
+from gvm.protocols.core import Request
+from gvm.utils import to_bool
+from gvm.xml import XmlCommand
+
+from .._entity_id import EntityID
+
+
+class ScannerType(Enum):
+    """Enum for scanner type"""
+
+    # 1 was removed (OSP_SCANNER_TYPE).
+    OPENVAS_SCANNER_TYPE = "2"
+    CVE_SCANNER_TYPE = "3"
+    GREENBONE_SENSOR_SCANNER_TYPE = "5"
+    OPENVASD_SCANNER_TYPE = "6"
+
+    @classmethod
+    def from_string(
+        cls,
+        scanner_type: Optional[str],
+    ) -> Optional["ScannerType"]:
+        """Convert a scanner type string to an actual ScannerType instance
+
+        Arguments:
+            scanner_type: Scanner type string to convert to a ScannerType
+        """
+        if not scanner_type:
+            return None
+
+        scanner_type = scanner_type.lower()
+
+        if (
+            scanner_type == cls.OPENVAS_SCANNER_TYPE.value
+            or scanner_type == "openvas"
+            or scanner_type == "openvas_scanner_type"
+        ):
+            return cls.OPENVAS_SCANNER_TYPE
+
+        if (
+            scanner_type == cls.CVE_SCANNER_TYPE.value
+            or scanner_type == "cve"
+            or scanner_type == "cve_scanner_type"
+        ):
+            return cls.CVE_SCANNER_TYPE
+
+        if (
+            scanner_type == cls.GREENBONE_SENSOR_SCANNER_TYPE.value
+            or scanner_type == "greenbone"
+            or scanner_type == "greenbone_sensor_scanner_type"
+        ):
+            return cls.GREENBONE_SENSOR_SCANNER_TYPE
+
+        if (
+            scanner_type == cls.OPENVASD_SCANNER_TYPE.value
+            or scanner_type == "openvasd"
+            or scanner_type == "openvasd_scanner_type"
+        ):
+            return cls.OPENVASD_SCANNER_TYPE
+
+        raise InvalidArgument(
+            argument="scanner_type", function=cls.from_string.__name__
+        )
+
+
+class Scanners:
+    @classmethod
+    def create_scanner(
+        cls,
+        name: str,
+        host: str,
+        port: Union[str, int],
+        scanner_type: ScannerType,
+        credential_id: str,
+        *,
+        ca_pub: Optional[str] = None,
+        comment: Optional[str] = None,
+        relay_host: Optional[str] = None,
+        relay_port: Optional[Union[str, int]] = None,
+    ) -> Request:
+        """Create a new scanner
+
+        Args:
+            name: Name of the new scanner
+            host: Hostname or IP address of the scanner
+            port: Port of the scanner
+            scanner_type: Type of the scanner
+            credential_id: UUID of client certificate credential for the
+                scanner
+            ca_pub: Certificate of CA to verify scanner certificate
+            comment: Comment for the scanner
+            relay_host: Hostname or IP address of the scanner relay
+            relay_port: Port of the scanner relay
+        """
+        if not name:
+            raise RequiredArgument(
+                function=cls.create_scanner.__name__, argument="name"
+            )
+
+        if not host:
+            raise RequiredArgument(
+                function=cls.create_scanner.__name__, argument="host"
+            )
+
+        if not port:
+            raise RequiredArgument(
+                function=cls.create_scanner.__name__, argument="port"
+            )
+
+        if not scanner_type:
+            raise RequiredArgument(
+                function=cls.create_scanner.__name__, argument="scanner_type"
+            )
+
+        if not credential_id:
+            raise RequiredArgument(
+                function=cls.create_scanner.__name__, argument="credential_id"
+            )
+
+        cmd = XmlCommand("create_scanner")
+        cmd.add_element("name", name)
+        cmd.add_element("host", host)
+        cmd.add_element("port", str(port))
+
+        if not isinstance(scanner_type, ScannerType):
+            scanner_type = ScannerType(scanner_type)
+
+        cmd.add_element("type", scanner_type.value)
+
+        cmd.add_element("credential", attrs={"id": str(credential_id)})
+
+        if ca_pub:
+            cmd.add_element("ca_pub", ca_pub)
+
+        if comment:
+            cmd.add_element("comment", comment)
+
+        if relay_host:
+            cmd.add_element("relay_host", relay_host)
+
+        if relay_port:
+            cmd.add_element("relay_port", str(relay_port))
+
+        return cmd
+
+    @classmethod
+    def modify_scanner(
+        cls,
+        scanner_id: EntityID,
+        *,
+        name: Optional[str] = None,
+        host: Optional[str] = None,
+        port: Optional[int] = None,
+        scanner_type: Optional[ScannerType] = None,
+        credential_id: Optional[EntityID] = None,
+        ca_pub: Optional[str] = None,
+        comment: Optional[str] = None,
+        relay_host: Optional[str] = None,
+        relay_port: Optional[Union[str, int]] = None,
+    ) -> Request:
+        """Modify an existing scanner
+
+        Args:
+            scanner_id: UUID of the scanner to modify
+            name: New name of the scanner
+            host: New hostname or IP address of the scanner
+            port: New port of the scanner
+            scanner_type: New type of the scanner
+            credential_id: New UUID of client certificate credential for the
+                scanner
+            ca_pub: New certificate of CA to verify scanner certificate
+            comment: New comment for the scanner
+            relay_host: Hostname or IP address of the scanner relay
+            relay_port: Port of the scanner relay
+        """
+        if not scanner_id:
+            raise RequiredArgument(
+                function=cls.modify_scanner.__name__, argument="scanner_id"
+            )
+
+        cmd = XmlCommand("modify_scanner")
+        cmd.set_attribute("scanner_id", str(scanner_id))
+
+        if scanner_type is not None:
+            if not isinstance(scanner_type, ScannerType):
+                scanner_type = ScannerType(scanner_type)
+            if not scanner_type:
+                raise InvalidArgument(
+                    argument="scanner_type",
+                    function=cls.modify_scanner.__name__,
+                )
+            cmd.add_element("type", scanner_type.value)
+
+        if host:
+            cmd.add_element("host", host)
+
+        if port:
+            cmd.add_element("port", str(port))
+
+        if comment:
+            cmd.add_element("comment", comment)
+
+        if name:
+            cmd.add_element("name", name)
+
+        if ca_pub:
+            cmd.add_element("ca_pub", ca_pub)
+
+        if credential_id:
+            cmd.add_element("credential", attrs={"id": str(credential_id)})
+
+        if relay_host:
+            cmd.add_element("relay_host", relay_host)
+
+        if relay_port:
+            cmd.add_element("relay_port", str(relay_port))
+
+        return cmd
+
+    @staticmethod
+    def get_scanners(
+        *,
+        filter_string: Optional[str] = None,
+        filter_id: Optional[EntityID] = None,
+        trash: Optional[bool] = None,
+        details: Optional[bool] = None,
+    ) -> Request:
+        """Request a list of scanners
+
+        Args:
+            filter_string: Filter term to use for the query
+            filter_id: UUID of an existing filter to use for the query
+            trash: Whether to get the trashcan scanners instead
+            details: Whether to include extra details like tasks using this
+                scanner
+        """
+        cmd = XmlCommand("get_scanners")
+        cmd.add_filter(filter_string, filter_id)
+
+        if trash is not None:
+            cmd.set_attribute("trash", to_bool(trash))
+
+        if details is not None:
+            cmd.set_attribute("details", to_bool(details))
+
+        return cmd
+
+    @classmethod
+    def get_scanner(cls, scanner_id: EntityID) -> Request:
+        """Request a single scanner
+
+        Args:
+            scanner_id: UUID of an existing scanner
+        """
+        if not scanner_id:
+            raise RequiredArgument(
+                function=cls.get_scanner.__name__, argument="scanner_id"
+            )
+
+        cmd = XmlCommand("get_scanners")
+        cmd.set_attribute("scanner_id", str(scanner_id))
+
+        # for single entity always request all details
+        cmd.set_attribute("details", "1")
+
+        return cmd
+
+    @classmethod
+    def verify_scanner(cls, scanner_id: EntityID) -> Request:
+        """Verify an existing scanner
+
+        Args:
+            scanner_id: UUID of an existing scanner
+        """
+        if not scanner_id:
+            raise RequiredArgument(
+                function=cls.verify_scanner.__name__, argument="scanner_id"
+            )
+
+        cmd = XmlCommand("verify_scanner")
+        cmd.set_attribute("scanner_id", str(scanner_id))
+
+        return cmd
+
+    @classmethod
+    def clone_scanner(cls, scanner_id: EntityID) -> Request:
+        """Clone an existing scanner
+
+        Args:
+            scanner_id: UUID of an existing scanner
+        """
+        if not scanner_id:
+            raise RequiredArgument(
+                function=cls.clone_scanner.__name__, argument="scanner_id"
+            )
+
+        cmd = XmlCommand("create_scanner")
+        cmd.add_element("copy", str(scanner_id))
+        return cmd
+
+    @classmethod
+    def delete_scanner(
+        cls, scanner_id: EntityID, ultimate: Optional[bool] = False
+    ) -> Request:
+        """Delete an existing scanner
+
+        Args:
+            scanner_id: UUID of an existing scanner
+        """
+        if not scanner_id:
+            raise RequiredArgument(
+                function=cls.delete_scanner.__name__, argument="scanner_id"
+            )
+
+        cmd = XmlCommand("delete_scanner")
+        cmd.set_attribute("scanner_id", str(scanner_id))
+        cmd.set_attribute("ultimate", to_bool(ultimate))
+
+        return cmd

--- a/tests/protocols/gmpv226/entities/test_scanners.py
+++ b/tests/protocols/gmpv226/entities/test_scanners.py
@@ -12,7 +12,7 @@ from ...gmpv224.entities.scanners import (
     GmpModifyScannerTestMixin,
 )
 from ...gmpv226 import GMPTestCase
-
+from gvm.protocols.gmp.requests.v226 import ScannerType
 
 class GMPDeleteScannerTestCase(GmpDeleteScannerTestMixin, GMPTestCase):
     pass
@@ -31,8 +31,98 @@ class GMPCloneScannerTestCase(GmpCloneScannerTestMixin, GMPTestCase):
 
 
 class GMPCreateScannerTestCase(GmpCreateScannerTestMixin, GMPTestCase):
-    pass
+    def test_create_scanner_with_openvasd_type(self):
+        self.gmp.create_scanner(
+            name="foo",
+            host="localhost",
+            port=1234,
+            scanner_type=ScannerType.OPENVASD_SCANNER_TYPE,
+            credential_id="c1",
+        )
 
+        self.connection.send.has_been_called_with(
+            b"<create_scanner>"
+            b"<name>foo</name>"
+            b"<host>localhost</host>"
+            b"<port>1234</port>"
+            b"<type>6</type>"
+            b'<credential id="c1"/>'
+            b"</create_scanner>"
+        )
 
+    def test_create_scanner_with_relay_host(self):
+        self.gmp.create_scanner(
+            name="foo",
+            host="remotehost",
+            port=1234,
+            scanner_type=ScannerType.OPENVASD_SCANNER_TYPE,
+            credential_id="c1",
+            relay_host="localhost",
+        )
+
+        self.connection.send.has_been_called_with(
+            b"<create_scanner>"
+            b"<name>foo</name>"
+            b"<host>remotehost</host>"
+            b"<port>1234</port>"
+            b"<type>6</type>"
+            b'<credential id="c1"/>'
+            b'<relay_host>localhost</relay_host>'
+            b"</create_scanner>"
+        )
+
+    def test_create_scanner_with_relay_port(self):
+        self.gmp.create_scanner(
+            name="foo",
+            host="remotehost",
+            port=1234,
+            scanner_type=ScannerType.OPENVASD_SCANNER_TYPE,
+            credential_id="c1",
+            relay_port=2345,
+        )
+
+        self.connection.send.has_been_called_with(
+            b"<create_scanner>"
+            b"<name>foo</name>"
+            b"<host>remotehost</host>"
+            b"<port>1234</port>"
+            b"<type>6</type>"
+            b'<credential id="c1"/>'
+            b'<relay_port>2345</relay_port>'
+            b"</create_scanner>"
+        )
 class GMPModifyScannerTestCase(GmpModifyScannerTestMixin, GMPTestCase):
-    pass
+    def test_modify_scanner_with_openvasd_type(self):
+        self.gmp.modify_scanner(
+            scanner_id="s1",
+            scanner_type=ScannerType.OPENVASD_SCANNER_TYPE,
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<modify_scanner scanner_id="s1">'
+            b'<type>6</type>'
+            b'</modify_scanner>'
+        )
+
+    def test_modify_scanner_with_relay_host(self):
+        self.gmp.modify_scanner(
+            scanner_id="s1",
+            relay_host="localhost",
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<modify_scanner scanner_id="s1">'
+            b'<relay_host>localhost</relay_host>'
+            b'</modify_scanner>'
+        )
+    def test_modify_scanner_with_relay_port(self):
+        self.gmp.modify_scanner(
+            scanner_id="s1",
+            relay_port=2345,
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<modify_scanner scanner_id="s1">'
+            b'<relay_port>2345</relay_port>'
+            b'</modify_scanner>'
+        )

--- a/tests/protocols/gmpv226/enums/test_scanner_type.py
+++ b/tests/protocols/gmpv226/enums/test_scanner_type.py
@@ -47,3 +47,10 @@ class GetScannerTypeFromStringTestCase(unittest.TestCase):
 
         ct = ScannerType.from_string("greenbone")
         self.assertEqual(ct, ScannerType.GREENBONE_SENSOR_SCANNER_TYPE)
+
+    def test_openvasd_scanner(self):
+        ct = ScannerType.from_string("6")
+        self.assertEqual(ct, ScannerType.OPENVASD_SCANNER_TYPE)
+
+        ct = ScannerType.from_string("openvasd")
+        self.assertEqual(ct, ScannerType.OPENVASD_SCANNER_TYPE)


### PR DESCRIPTION
## What
The latest GMP protocol version now supports the openvasd scanner type and the new scanner fields relay_host and relay_port.

## Why
To be able to use the new scanner type and define relays for scanners.

## References
GEA-987
The new optional relay fields require greenbone/gvmd/pull/2399

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


