### PR TITLE
Fix: Fix typo in protocol warning message

### DIFF
--- a/gvm/protocols/gmp/_gmp.py
+++ b/gvm/protocols/gmp/_gmp.py
@@ -100,7 +100,7 @@ class GMP(GvmProtocol[T]):
             gmp_class = GMPv226
             if minor_version > 6:
                 warnings.warn(
-                    "Remote manager daemon uses a newer GMP version then "
+                    "Remote manager daemon uses a newer GMP version than "
                     f"supported by python-gvm {__version__}. Please update to "
                     "a newer release of python-gvm if possible. "
                     f"Remote GMP version is {major_version}.{minor_version}. "


### PR DESCRIPTION
## What and why

Fix a typo in a warning message. Previously, `python-gvm` complained about the remote version being "newer _then_" when it should read "newer _than_".