### PR TITLE
Added the option to use configs of format templates

### DIFF
--- a/gvm/protocols/gmp/_gmp226.py
+++ b/gvm/protocols/gmp/_gmp226.py
@@ -103,6 +103,7 @@ class GMPv226(GMPv225[T]):
         filter_id: Optional[str] = None,
         delta_report_id: Optional[EntityID] = None,
         report_format_id: Optional[Union[str, ReportFormatType]] = None,
+        report_config_id: Optional[str] = None,
         ignore_pagination: Optional[bool] = None,
         details: Optional[bool] = True,
     ) -> T:
@@ -115,6 +116,7 @@ class GMPv226(GMPv225[T]):
             delta_report_id: UUID of an existing report to compare report to.
             report_format_id: UUID of report format to use
                               or ReportFormatType (enum)
+            report_config_id: UUID of report format config to use
             ignore_pagination: Whether to ignore the filter terms "first" and
                 "rows".
             details: Request additional report information details
@@ -127,6 +129,7 @@ class GMPv226(GMPv225[T]):
                 filter_id=filter_id,
                 delta_report_id=delta_report_id,
                 report_format_id=report_format_id,
+                report_config_id=report_config_id,
                 ignore_pagination=ignore_pagination,
                 details=details,
             )

--- a/gvm/protocols/gmp/requests/v226/_reports.py
+++ b/gvm/protocols/gmp/requests/v226/_reports.py
@@ -41,6 +41,7 @@ class Reports:
         filter_id: Optional[str] = None,
         delta_report_id: Optional[EntityID] = None,
         report_format_id: Optional[Union[str, ReportFormatType]] = None,
+        report_config_id: Optional[str] = None,
         ignore_pagination: Optional[bool] = None,
         details: Optional[bool] = True,
     ) -> Request:
@@ -53,6 +54,7 @@ class Reports:
             delta_report_id: UUID of an existing report to compare report to.
             report_format_id: UUID of report format to use
                               or ReportFormatType (enum)
+            report_config_id: UUID of report format config to use
             ignore_pagination: Whether to ignore the filter terms "first" and
                 "rows".
             details: Request additional report information details
@@ -75,6 +77,9 @@ class Reports:
 
         if report_format_id:
             cmd.set_attribute("format_id", str(report_format_id))
+
+        if report_config_id:
+            cmd.set_attribute("config_id", str(report_config_id))
 
         if ignore_pagination is not None:
             cmd.set_attribute("ignore_pagination", to_bool(ignore_pagination))

--- a/tests/protocols/gmp/requests/v226/test_reports.py
+++ b/tests/protocols/gmp/requests/v226/test_reports.py
@@ -72,6 +72,17 @@ class ReportsTestCase(unittest.TestCase):
             b'<get_reports report_id="report_id" usage_type="scan" format_id="report_format_id" details="1"/>',
         )
 
+    def test_get_report_with_report_format_id_and_config_id(self):
+        request = Reports.get_report(
+            "report_id",
+            report_format_id="report_format_id",
+            report_config_id="report_config_id",
+        )
+        self.assertEqual(
+            bytes(request),
+            b'<get_reports report_id="report_id" usage_type="scan" format_id="report_format_id" config_id="report_config_id" details="1"/>',
+        )
+
     def test_get_report_with_ignore_pagination(self):
         request = Reports.get_report("report_id", ignore_pagination=True)
         self.assertEqual(

--- a/tests/protocols/gmpv226/entities/reports/test_get_report.py
+++ b/tests/protocols/gmpv226/entities/reports/test_get_report.py
@@ -36,6 +36,15 @@ class GmpGetReportTestMixin:
             b'<get_reports report_id="r1" usage_type="scan" format_id="bar" details="1"/>'
         )
 
+    def test_get_report_with_report_format_id_and_config_id(self):
+        self.gmp.get_report(
+            report_id="r1", report_format_id="bar", report_config_id="c1"
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_reports report_id="r1" usage_type="scan" format_id="bar" config_id="c1" details="1"/>'
+        )
+
     def test_get_report_with_report_format_type(self):
         self.gmp.get_report(
             report_id="r1", report_format_id=ReportFormatType.TXT


### PR DESCRIPTION


## What
added the option to use the config id with get_report to get customizable reports

## Why

It was not possible to add a config to the format that was selected. Therefore it was only possible to use the already existing formats from Greenbone and not the custom configs to enable different fields.

This is my first contribution ever so please let me know if there are things that i missed or should do differently :)


