### PR TITLE
add argument task_limit for get_tasks to easily (de-)limit the amount…

### DIFF
--- a/gvm/protocols/gmp/_gmp224.py
+++ b/gvm/protocols/gmp/_gmp224.py
@@ -3843,6 +3843,7 @@ class GMPv224(GvmProtocol[T]):
         *,
         filter_string: Optional[str] = None,
         filter_id: Optional[EntityID] = None,
+        task_limit: Optional[int] = None,
         trash: Optional[bool] = None,
         details: Optional[bool] = None,
         schedules_only: Optional[bool] = None,
@@ -3853,6 +3854,7 @@ class GMPv224(GvmProtocol[T]):
         Args:
             filter_string: Filter term to use for the query
             filter_id: UUID of an existing filter to use for the query
+            task_limit: Limits the amount of tasks being returned (Default:10)
             trash: Whether to get the trashcan tasks instead
             details: Whether to include full task details
             schedules_only: Whether to only include id, name and schedule
@@ -3864,6 +3866,7 @@ class GMPv224(GvmProtocol[T]):
             Tasks.get_tasks(
                 filter_string=filter_string,
                 filter_id=filter_id,
+                task_limit=task_limit,
                 trash=trash,
                 details=details,
                 schedules_only=schedules_only,

--- a/gvm/protocols/gmp/requests/v224/_tasks.py
+++ b/gvm/protocols/gmp/requests/v224/_tasks.py
@@ -197,6 +197,7 @@ class Tasks:
         *,
         filter_string: Optional[str] = None,
         filter_id: Optional[EntityID] = None,
+        task_limit: Optional[int] = None,
         trash: Optional[bool] = None,
         details: Optional[bool] = None,
         schedules_only: Optional[bool] = None,
@@ -207,6 +208,7 @@ class Tasks:
         Args:
             filter_string: Filter term to use for the query
             filter_id: UUID of an existing filter to use for the query
+            task_limit: Limits the amount of tasks being returned (Default:10)
             trash: Whether to get the trashcan tasks instead
             details: Whether to include full task details
             schedules_only: Whether to only include id, name and schedule
@@ -216,6 +218,12 @@ class Tasks:
         """
         cmd = XmlCommand("get_tasks")
         cmd.set_attribute("usage_type", "scan")
+
+        if task_limit is not None:
+            if filter_string is None:
+                filter_string = f"rows={task_limit}"
+            else:
+                filter_string += f" rows={task_limit}"
 
         cmd.add_filter(filter_string, filter_id)
 

--- a/tests/protocols/gmp/requests/v224/test_tasks.py
+++ b/tests/protocols/gmp/requests/v224/test_tasks.py
@@ -414,6 +414,20 @@ class TasksTestCase(unittest.TestCase):
             b'<get_tasks usage_type="scan" filt_id="filter_id"/>',
         )
 
+    def test_get_tasks_with_task_limit(self):
+        request = Tasks().get_tasks(task_limit=5)
+        self.assertEqual(
+            bytes(request),
+            b'<get_tasks usage_type="scan" filter="rows=5"/>',
+        )
+
+    def test_get_tasks_with_task_limit_and_filter_string(self):
+        request = Tasks().get_tasks(filter_string="foo", task_limit=5)
+        self.assertEqual(
+            bytes(request),
+            b'<get_tasks usage_type="scan" filter="foo rows=5"/>',
+        )
+
     def test_get_tasks_with_trash(self):
         request = Tasks().get_tasks(trash=True)
         self.assertEqual(

--- a/tests/protocols/gmpv224/entities/tasks/test_get_tasks.py
+++ b/tests/protocols/gmpv224/entities/tasks/test_get_tasks.py
@@ -26,6 +26,20 @@ class GmpGetTasksTestMixin:
             b'<get_tasks usage_type="scan" filt_id="f1"/>'
         )
 
+    def test_get_tasks_with_task_limit(self):
+        self.gmp.get_tasks(task_limit="5")
+
+        self.connection.send.has_been_called_with(
+            b'<get_tasks usage_type="scan" filter="rows=5"/>'
+        )
+
+    def test_get_tasks_with_task_limit_and_filter_string(self):
+        self.gmp.get_tasks(filter_string="foo", task_limit="5")
+
+        self.connection.send.has_been_called_with(
+            b'<get_tasks usage_type="scan" filter="foo rows=5"/>'
+        )
+
     def test_get_tasks_from_trash(self):
         self.gmp.get_tasks(trash=True)
 


### PR DESCRIPTION
... of tasks requested

## What

Added the argument task_limit which adds a "rows=x" to the filter_string that is being send with the request.
If a filter_id is being used, the task_limit is being ignored.
If a filter_string is used with "rows=x", the task_limit is being ignored.
If a filter_string is used without setting the "rows" parameter, the task_limit is used.
If no filter_string is set, the task_limit is used.

## Why

When using the library I didn't realise that using get_tasks() to get "all" tasks only returns 10 tasks by default. To make it easier changeable and more obvious that there is a default limit, this parameter could get added. However I can also understand if it is not necessary as it can also be manually set by using 'filter_string="rows=x"'.

## Checklist

<!-- Remove this section if not applicable to your changes -->

Tests are created in: 
- tests/protocols/gmp/requests/v224/test_tasks.py both for with and without a filter_string
- tests/protocols/gmpv224/entities/tasks/test_get_tasks.py both for with and without a filter_string


