### PR TITLE
Change: Rename modify_agents and delete_agents to modify_agent and delete_agent

### DIFF
--- a/gvm/protocols/gmp/requests/next/_agents.py
+++ b/gvm/protocols/gmp/requests/next/_agents.py
@@ -224,7 +224,7 @@ class Agents:
                 function=cls.modify_agents.__name__, argument="agent_ids"
             )
 
-        cmd = XmlCommand("modify_agents")
+        cmd = XmlCommand("modify_agent")
         xml_agents = cmd.add_element("agents")
 
         for agent_id in agent_ids:
@@ -256,7 +256,7 @@ class Agents:
                 function=cls.delete_agents.__name__, argument="agent_ids"
             )
 
-        cmd = XmlCommand("delete_agents")
+        cmd = XmlCommand("delete_agent")
         xml_agents = cmd.add_element("agents")
 
         for agent_id in agent_ids:

--- a/tests/protocols/gmpnext/entities/agents/test_delete_agents.py
+++ b/tests/protocols/gmpnext/entities/agents/test_delete_agents.py
@@ -10,9 +10,9 @@ class GmpDeleteAgentsTestMixin:
         self.gmp.delete_agents(agent_ids=["agent-123", "agent-456"])
 
         self.connection.send.has_been_called_with(
-            b"<delete_agents>"
+            b"<delete_agent>"
             b'<agents><agent id="agent-123"/><agent id="agent-456"/></agents>'
-            b"</delete_agents>"
+            b"</delete_agent>"
         )
 
     def test_delete_agents_without_ids(self):

--- a/tests/protocols/gmpnext/entities/agents/test_modify_agents.py
+++ b/tests/protocols/gmpnext/entities/agents/test_modify_agents.py
@@ -10,9 +10,9 @@ class GmpModifyAgentsTestMixin:
         self.gmp.modify_agents(agent_ids=["agent-123"])
 
         self.connection.send.has_been_called_with(
-            b"<modify_agents>"
+            b"<modify_agent>"
             b'<agents><agent id="agent-123"/></agents>'
-            b"</modify_agents>"
+            b"</modify_agent>"
         )
 
     def test_modify_agents_with_authorized_only(self):
@@ -21,10 +21,10 @@ class GmpModifyAgentsTestMixin:
         )
 
         self.connection.send.has_been_called_with(
-            b"<modify_agents>"
+            b"<modify_agent>"
             b'<agents><agent id="agent-123"/><agent id="agent-456"/></agents>'
             b"<authorized>1</authorized>"
-            b"</modify_agents>"
+            b"</modify_agent>"
         )
 
     def test_modify_agents_with_full_config_and_comment(self):
@@ -53,7 +53,7 @@ class GmpModifyAgentsTestMixin:
         )
 
         self.connection.send.has_been_called_with(
-            b"<modify_agents>"
+            b"<modify_agent>"
             b'<agents><agent id="agent-123"/><agent id="agent-456"/></agents>'
             b"<authorized>1</authorized>"
             b"<config>"
@@ -78,7 +78,7 @@ class GmpModifyAgentsTestMixin:
             b"</heartbeat>"
             b"</config>"
             b"<comment>Updated agents</comment>"
-            b"</modify_agents>"
+            b"</modify_agent>"
         )
 
     def test_modify_agents_with_full_config_with_missing_element(self):


### PR DESCRIPTION
## What

Renamed the commands `modify_agents` and `delete_agents` to `modify_agent` and `delete_agent`.



## Why

To ensure consistency in command naming and reduce confusion. 


## References

GEA-1278

## Checklist

- [x] Tests


