### PR TITLE
Don't group dependabot python updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,15 +5,8 @@ updates:
     schedule:
       interval: weekly
       time: "04:00"
-    allow:
-      - dependency-type: direct
-      - dependency-type: indirect
     commit-message:
       prefix: "Deps"
-    groups:
-      python-packages:
-        patterns:
-          - "*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION


## What

Don't group dependabot python updates

## Why

It is better to apply each update individually if some update breaks the build.


