### PR TITLE
Use correct package-ecosystem in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,6 @@
 version: 2
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: "/"
     schedule:
       interval: weekly


### PR DESCRIPTION

## What

Use correct package-ecosystem in dependabot config

## Why

Use uv as the desired package-ecosystem according to the docs at https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#package-ecosystem-


