### PR TITLE
add: add get_report_ports GMP request

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -20,6 +20,7 @@ from .requests.next import (
     IntegrationConfigs,
     OCIImageTargets,
     ReportHosts,
+    ReportPorts,
     Tasks,
 )
 from .requests.v224 import HostsOrdering
@@ -1016,6 +1017,36 @@ class GMPNext(GMPv227[T]):
         """
         return self._send_request_and_transform_response(
             ReportHosts.get_report_hosts(
+                report_id=report_id,
+                filter_string=filter_string,
+                filter_id=filter_id,
+                ignore_pagination=ignore_pagination,
+                details=details,
+            )
+        )
+
+    def get_report_ports(
+        self,
+        report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> T:
+        """Request ports of a single report.
+
+        Args:
+            report_id: UUID of an existing report.
+            filter_string: Filter term to use to filter results in the report
+            filter_id: UUID of filter to use to filter results in the report
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report port information details.
+                Defaults to True.
+        """
+        return self._send_request_and_transform_response(
+            ReportPorts.get_report_ports(
                 report_id=report_id,
                 filter_string=filter_string,
                 filter_id=filter_id,

--- a/gvm/protocols/gmp/requests/next/__init__.py
+++ b/gvm/protocols/gmp/requests/next/__init__.py
@@ -17,6 +17,9 @@ from gvm.protocols.gmp.requests.next._oci_image_targets import OCIImageTargets
 from gvm.protocols.gmp.requests.next._report_hosts import (
     ReportHosts,
 )
+from gvm.protocols.gmp.requests.next._report_ports import (
+    ReportPorts,
+)
 from gvm.protocols.gmp.requests.next._tasks import Tasks
 
 from .._entity_id import EntityID
@@ -140,6 +143,7 @@ __all__ = (
     "ReportFormatType",
     "ReportFormats",
     "ReportHosts",
+    "ReportPorts",
     "Reports",
     "ResourceNames",
     "ResourceType",

--- a/gvm/protocols/gmp/requests/next/_report_ports.py
+++ b/gvm/protocols/gmp/requests/next/_report_ports.py
@@ -1,0 +1,46 @@
+from gvm.errors import RequiredArgument
+from gvm.protocols.core import Request
+from gvm.protocols.gmp.requests import EntityID
+from gvm.utils import to_bool
+from gvm.xml import XmlCommand
+
+
+class ReportPorts:
+    @classmethod
+    def get_report_ports(
+        cls,
+        report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> Request:
+        """Request ports of a single report.
+
+        Args:
+            report_id: UUID of an existing report.
+            filter_string: Filter term to use to filter results in the report
+            filter_id: UUID of filter to use to filter results in the report
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report port information details.
+                Defaults to True.
+        """
+        cmd = XmlCommand("get_report_ports")
+
+        if not report_id:
+            raise RequiredArgument(
+                function=cls.get_report_ports.__name__, argument="report_id"
+            )
+
+        cmd.set_attribute("report_id", str(report_id))
+
+        cmd.add_filter(filter_string, filter_id)
+
+        if ignore_pagination is not None:
+            cmd.set_attribute("ignore_pagination", to_bool(ignore_pagination))
+
+        cmd.set_attribute("details", to_bool(details))
+
+        return cmd

--- a/tests/protocols/gmpnext/entities/report_ports/test_get_report_ports.py
+++ b/tests/protocols/gmpnext/entities/report_ports/test_get_report_ports.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gvm.errors import RequiredArgument
+
+
+class GmpGetReportPortsTestMixin:
+    def test_get_report_ports_without_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_ports(None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_ports("")
+
+    def test_get_report_ports_with_filter_string(self):
+        self.gmp.get_report_ports(report_id="r1", filter_string="name=foo")
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_ports report_id="r1" filter="name=foo" details="1"/>'
+        )
+
+    def test_get_report_ports_with_filter_id(self):
+        self.gmp.get_report_ports(report_id="r1", filter_id="f1")
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_ports report_id="r1" filt_id="f1" details="1"/>'
+        )
+
+    def test_get_report_ports_with_ignore_pagination(self):
+        self.gmp.get_report_ports(report_id="r1", ignore_pagination=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_ports report_id="r1" ignore_pagination="1" details="1"/>'
+        )
+
+        self.gmp.get_report_ports(report_id="r1", ignore_pagination=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_ports report_id="r1" ignore_pagination="0" details="1"/>'
+        )
+
+    def test_get_report_ports_with_details(self):
+        self.gmp.get_report_ports(report_id="r1", details=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_ports report_id="r1" details="1"/>'
+        )
+
+        self.gmp.get_report_ports(report_id="r1", details=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_ports report_id="r1" details="0"/>'
+        )

--- a/tests/protocols/gmpnext/entities/test_report_ports.py
+++ b/tests/protocols/gmpnext/entities/test_report_ports.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from ...gmpnext import GMPTestCase
+from .report_ports.test_get_report_ports import (
+    GmpGetReportPortsTestMixin,
+)
+
+
+class GmpGetReportPortsTestCase(GmpGetReportPortsTestMixin, GMPTestCase):
+    pass


### PR DESCRIPTION
## What

Implement the `get_report_ports` GMP request command.

## Why

To enable retrieving report port data  with the python-gvm.

## References

GEA-1710

## Checklist

- [x] Tests


