### PR TITLE
add: add get_report_operating_systems GMP request

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -21,6 +21,7 @@ from .requests.next import (
     OCIImageTargets,
     ReportApplications,
     ReportHosts,
+    ReportOperatingSystems,
     ReportPorts,
     Tasks,
 )
@@ -1018,6 +1019,36 @@ class GMPNext(GMPv227[T]):
         """
         return self._send_request_and_transform_response(
             ReportHosts.get_report_hosts(
+                report_id=report_id,
+                filter_string=filter_string,
+                filter_id=filter_id,
+                ignore_pagination=ignore_pagination,
+                details=details,
+            )
+        )
+
+    def get_report_operating_systems(
+        self,
+        report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> T:
+        """Request operating systems of a single report.
+
+        Args:
+            report_id: UUID of an existing report.
+            filter_string: Filter term to use to filter results in the report
+            filter_id: UUID of filter to use to filter results in the report
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report operating system information details.
+                Defaults to True.
+        """
+        return self._send_request_and_transform_response(
+            ReportOperatingSystems.get_report_operating_systems(
                 report_id=report_id,
                 filter_string=filter_string,
                 filter_id=filter_id,

--- a/gvm/protocols/gmp/requests/next/__init__.py
+++ b/gvm/protocols/gmp/requests/next/__init__.py
@@ -20,6 +20,9 @@ from gvm.protocols.gmp.requests.next._report_applications import (
 from gvm.protocols.gmp.requests.next._report_hosts import (
     ReportHosts,
 )
+from gvm.protocols.gmp.requests.next._report_operating_systems import (
+    ReportOperatingSystems,
+)
 from gvm.protocols.gmp.requests.next._report_ports import (
     ReportPorts,
 )
@@ -147,6 +150,7 @@ __all__ = (
     "ReportFormatType",
     "ReportFormats",
     "ReportHosts",
+    "ReportOperatingSystems",
     "ReportPorts",
     "Reports",
     "ResourceNames",

--- a/gvm/protocols/gmp/requests/next/_report_operating_systems.py
+++ b/gvm/protocols/gmp/requests/next/_report_operating_systems.py
@@ -1,0 +1,47 @@
+from gvm.errors import RequiredArgument
+from gvm.protocols.core import Request
+from gvm.protocols.gmp.requests import EntityID
+from gvm.utils import to_bool
+from gvm.xml import XmlCommand
+
+
+class ReportOperatingSystems:
+    @classmethod
+    def get_report_operating_systems(
+        cls,
+        report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> Request:
+        """Request operating systems of a single report.
+
+        Args:
+            report_id: UUID of an existing report.
+            filter_string: Filter term to use to filter results in the report
+            filter_id: UUID of filter to use to filter results in the report
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report operating systems information details.
+                Defaults to True.
+        """
+        cmd = XmlCommand("get_report_operating_systems")
+
+        if not report_id:
+            raise RequiredArgument(
+                function=cls.get_report_operating_systems.__name__,
+                argument="report_id",
+            )
+
+        cmd.set_attribute("report_id", str(report_id))
+
+        cmd.add_filter(filter_string, filter_id)
+
+        if ignore_pagination is not None:
+            cmd.set_attribute("ignore_pagination", to_bool(ignore_pagination))
+
+        cmd.set_attribute("details", to_bool(details))
+
+        return cmd

--- a/tests/protocols/gmpnext/entities/report_operating_systems/test_get_report_operating_systems.py
+++ b/tests/protocols/gmpnext/entities/report_operating_systems/test_get_report_operating_systems.py
@@ -1,0 +1,61 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gvm.errors import RequiredArgument
+
+
+class GmpGetReportOperatingSystemsTestMixin:
+    def test_get_report_operating_systems_without_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_operating_systems(None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_operating_systems("")
+
+    def test_get_report_operating_systems_with_filter_string(self):
+        self.gmp.get_report_operating_systems(
+            report_id="r1", filter_string="name=foo"
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_operating_systems report_id="r1" filter="name=foo" details="1"/>'
+        )
+
+    def test_get_report_operating_systems_with_filter_id(self):
+        self.gmp.get_report_operating_systems(report_id="r1", filter_id="f1")
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_operating_systems report_id="r1" filt_id="f1" details="1"/>'
+        )
+
+    def test_get_report_operating_systems_with_ignore_pagination(self):
+        self.gmp.get_report_operating_systems(
+            report_id="r1", ignore_pagination=True
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_operating_systems report_id="r1" ignore_pagination="1" details="1"/>'
+        )
+
+        self.gmp.get_report_operating_systems(
+            report_id="r1", ignore_pagination=False
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_operating_systems report_id="r1" ignore_pagination="0" details="1"/>'
+        )
+
+    def test_get_report_operating_systems_with_details(self):
+        self.gmp.get_report_operating_systems(report_id="r1", details=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_operating_systems report_id="r1" details="1"/>'
+        )
+
+        self.gmp.get_report_operating_systems(report_id="r1", details=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_operating_systems report_id="r1" details="0"/>'
+        )

--- a/tests/protocols/gmpnext/entities/test_report_operating_systems.py
+++ b/tests/protocols/gmpnext/entities/test_report_operating_systems.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from ...gmpnext import GMPTestCase
+from .report_operating_systems.test_get_report_operating_systems import (
+    GmpGetReportOperatingSystemsTestMixin,
+)
+
+
+class GmpGetReportOperatingSystemsTestCase(
+    GmpGetReportOperatingSystemsTestMixin, GMPTestCase
+):
+    pass


### PR DESCRIPTION
## What

Implement the `get_report_operating_systems` GMP request command.

## Why

To enable retrieving report operating system data  with the python-gvm.

## References

GEA-1710

## Checklist

- [x] Tests


