### PR TITLE
add: add get_report_closed_cves GMP request

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -20,6 +20,7 @@ from .requests.next import (
     IntegrationConfigs,
     OCIImageTargets,
     ReportApplications,
+    ReportClosedCVEs,
     ReportCVEs,
     ReportHosts,
     ReportOperatingSystems,
@@ -1143,6 +1144,30 @@ class GMPNext(GMPv227[T]):
                 report_id=report_id,
                 filter_string=filter_string,
                 filter_id=filter_id,
+                ignore_pagination=ignore_pagination,
+                details=details,
+            )
+        )
+
+    def get_report_closed_cves(
+        self,
+        report_id: EntityID,
+        *,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> T:
+        """Request closed CVEs of a single report.
+
+        Args:
+            report_id: UUID of an existing report.
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report closed CVE information details.
+                Defaults to True.
+        """
+        return self._send_request_and_transform_response(
+            ReportClosedCVEs.get_report_closed_cves(
+                report_id=report_id,
                 ignore_pagination=ignore_pagination,
                 details=details,
             )

--- a/gvm/protocols/gmp/requests/next/__init__.py
+++ b/gvm/protocols/gmp/requests/next/__init__.py
@@ -17,6 +17,9 @@ from gvm.protocols.gmp.requests.next._oci_image_targets import OCIImageTargets
 from gvm.protocols.gmp.requests.next._report_applications import (
     ReportApplications,
 )
+from gvm.protocols.gmp.requests.next._report_closed_cves import (
+    ReportClosedCVEs,
+)
 from gvm.protocols.gmp.requests.next._report_cves import (
     ReportCVEs,
 )
@@ -149,6 +152,7 @@ __all__ = (
     "PortRangeType",
     "ReportApplications",
     "ReportCVEs",
+    "ReportClosedCVEs",
     "ReportConfigParameter",
     "ReportConfigs",
     "ReportFormatType",

--- a/gvm/protocols/gmp/requests/next/_report_closed_cves.py
+++ b/gvm/protocols/gmp/requests/next/_report_closed_cves.py
@@ -1,0 +1,41 @@
+from gvm.errors import RequiredArgument
+from gvm.protocols.core import Request
+from gvm.protocols.gmp.requests import EntityID
+from gvm.utils import to_bool
+from gvm.xml import XmlCommand
+
+
+class ReportClosedCVEs:
+    @classmethod
+    def get_report_closed_cves(
+        cls,
+        report_id: EntityID,
+        *,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> Request:
+        """Request closed CVEs of a single report.
+
+        Args:
+            report_id: UUID of an existing report.
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report closed CVE information details.
+                Defaults to True.
+        """
+        cmd = XmlCommand("get_report_closed_cves")
+
+        if not report_id:
+            raise RequiredArgument(
+                function=cls.get_report_closed_cves.__name__,
+                argument="report_id",
+            )
+
+        cmd.set_attribute("report_id", str(report_id))
+
+        if ignore_pagination is not None:
+            cmd.set_attribute("ignore_pagination", to_bool(ignore_pagination))
+
+        cmd.set_attribute("details", to_bool(details))
+
+        return cmd

--- a/tests/protocols/gmpnext/entities/report_closed_cves/test_get_report_closed_cves.py
+++ b/tests/protocols/gmpnext/entities/report_closed_cves/test_get_report_closed_cves.py
@@ -1,0 +1,41 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gvm.errors import RequiredArgument
+
+
+class GmpGetReportClosedCVEsTestMixin:
+    def test_get_report_closed_cves_without_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_closed_cves(None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_closed_cves("")
+
+    def test_get_report_closed_cves_with_ignore_pagination(self):
+        self.gmp.get_report_closed_cves(report_id="r1", ignore_pagination=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_closed_cves report_id="r1" ignore_pagination="1" details="1"/>'
+        )
+
+        self.gmp.get_report_closed_cves(report_id="r1", ignore_pagination=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_closed_cves report_id="r1" ignore_pagination="0" details="1"/>'
+        )
+
+    def test_get_report_closed_cves_with_details(self):
+        self.gmp.get_report_closed_cves(report_id="r1", details=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_closed_cves report_id="r1" details="1"/>'
+        )
+
+        self.gmp.get_report_closed_cves(report_id="r1", details=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_closed_cves report_id="r1" details="0"/>'
+        )

--- a/tests/protocols/gmpnext/entities/test_report_closed_cves.py
+++ b/tests/protocols/gmpnext/entities/test_report_closed_cves.py
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from ...gmpnext import GMPTestCase
+from .report_closed_cves.test_get_report_closed_cves import (
+    GmpGetReportClosedCVEsTestMixin,
+)
+
+
+class GmpGetReportClosedCVEsTestCase(
+    GmpGetReportClosedCVEsTestMixin, GMPTestCase
+):
+    pass


### PR DESCRIPTION
## What

Implement the `get_report_closed_cves` GMP request command.

## Why

To enable retrieving report closed cve data  with the python-gvm.

## References

GEA-1710

## Checklist

- [x] Tests








