### PR TITLE
add: add get_report_errors GMP request

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -22,6 +22,7 @@ from .requests.next import (
     ReportApplications,
     ReportClosedCVEs,
     ReportCVEs,
+    ReportErrors,
     ReportHosts,
     ReportOperatingSystems,
     ReportPorts,
@@ -1199,6 +1200,36 @@ class GMPNext(GMPv227[T]):
         return self._send_request_and_transform_response(
             ReportClosedCVEs.get_report_closed_cves(
                 report_id=report_id,
+                ignore_pagination=ignore_pagination,
+                details=details,
+            )
+        )
+
+    def get_report_errors(
+        self,
+        report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> T:
+        """Request errors of a single report.
+
+        Args:
+            report_id: UUID of an existing report.
+            filter_string: Filter term to use to filter results in the report
+            filter_id: UUID of filter to use to filter results in the report
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report error information details.
+                Defaults to True.
+        """
+        return self._send_request_and_transform_response(
+            ReportErrors.get_report_errors(
+                report_id=report_id,
+                filter_string=filter_string,
+                filter_id=filter_id,
                 ignore_pagination=ignore_pagination,
                 details=details,
             )

--- a/gvm/protocols/gmp/requests/next/__init__.py
+++ b/gvm/protocols/gmp/requests/next/__init__.py
@@ -23,6 +23,9 @@ from gvm.protocols.gmp.requests.next._report_closed_cves import (
 from gvm.protocols.gmp.requests.next._report_cves import (
     ReportCVEs,
 )
+from gvm.protocols.gmp.requests.next._report_errors import (
+    ReportErrors,
+)
 from gvm.protocols.gmp.requests.next._report_hosts import (
     ReportHosts,
 )
@@ -158,6 +161,7 @@ __all__ = (
     "ReportClosedCVEs",
     "ReportConfigParameter",
     "ReportConfigs",
+    "ReportErrors",
     "ReportFormatType",
     "ReportFormats",
     "ReportHosts",

--- a/gvm/protocols/gmp/requests/next/_report_errors.py
+++ b/gvm/protocols/gmp/requests/next/_report_errors.py
@@ -1,0 +1,46 @@
+from gvm.errors import RequiredArgument
+from gvm.protocols.core import Request
+from gvm.protocols.gmp.requests import EntityID
+from gvm.utils import to_bool
+from gvm.xml import XmlCommand
+
+
+class ReportErrors:
+    @classmethod
+    def get_report_errors(
+        cls,
+        report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> Request:
+        """Request errors of a single report.
+
+        Args:
+            report_id: UUID of an existing report.
+            filter_string: Filter term to use to filter results in the report
+            filter_id: UUID of filter to use to filter results in the report
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report error information details.
+                Defaults to True.
+        """
+        cmd = XmlCommand("get_report_errors")
+
+        if not report_id:
+            raise RequiredArgument(
+                function=cls.get_report_errors.__name__, argument="report_id"
+            )
+
+        cmd.set_attribute("report_id", str(report_id))
+
+        cmd.add_filter(filter_string, filter_id)
+
+        if ignore_pagination is not None:
+            cmd.set_attribute("ignore_pagination", to_bool(ignore_pagination))
+
+        cmd.set_attribute("details", to_bool(details))
+
+        return cmd

--- a/tests/protocols/gmpnext/entities/report_errors/test_get_report_errors.py
+++ b/tests/protocols/gmpnext/entities/report_errors/test_get_report_errors.py
@@ -1,0 +1,55 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gvm.errors import RequiredArgument
+
+
+class GmpGetReportErrorsTestMixin:
+    def test_get_report_errors_without_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_errors(None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_errors("")
+
+    def test_get_report_errors_with_filter_string(self):
+        self.gmp.get_report_errors(report_id="r1", filter_string="name=foo")
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_errors report_id="r1" filter="name=foo" details="1"/>'
+        )
+
+    def test_get_report_errors_with_filter_id(self):
+        self.gmp.get_report_errors(report_id="r1", filter_id="f1")
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_errors report_id="r1" filt_id="f1" details="1"/>'
+        )
+
+    def test_get_report_errors_with_ignore_pagination(self):
+        self.gmp.get_report_errors(report_id="r1", ignore_pagination=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_errors report_id="r1" ignore_pagination="1" details="1"/>'
+        )
+
+        self.gmp.get_report_errors(report_id="r1", ignore_pagination=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_errors report_id="r1" ignore_pagination="0" details="1"/>'
+        )
+
+    def test_get_report_errors_with_details(self):
+        self.gmp.get_report_errors(report_id="r1", details=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_errors report_id="r1" details="1"/>'
+        )
+
+        self.gmp.get_report_errors(report_id="r1", details=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_errors report_id="r1" details="0"/>'
+        )

--- a/tests/protocols/gmpnext/entities/test_report_errors.py
+++ b/tests/protocols/gmpnext/entities/test_report_errors.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from ...gmpnext import GMPTestCase
+from .report_errors.test_get_report_errors import (
+    GmpGetReportErrorsTestMixin,
+)
+
+
+class GmpGetReportErrorsTestCase(GmpGetReportErrorsTestMixin, GMPTestCase):
+    pass


### PR DESCRIPTION
## What

Implement the `get_report_errors` GMP request command.

## Why

To enable retrieving report error data  with the python-gvm.

## References

GEA-1710

## Checklist

- [x] Tests











