### PR TITLE
fix: fix agent group command by adding scheduler_cron_time

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -228,6 +228,7 @@ class GMPNext(GMPv227[T]):
         self,
         name: str,
         agent_ids: list[str],
+        scheduler_cron_time: str,
         *,
         comment: str | None = None,
     ) -> T:
@@ -236,6 +237,7 @@ class GMPNext(GMPv227[T]):
         Args:
             name: Name of the new agent group.
             agent_ids: List of agent UUIDs to include in the group (required).
+            scheduler_cron_time: Scheduler cron to use.
             comment: Optional comment for the group.
 
         Raises:
@@ -246,12 +248,14 @@ class GMPNext(GMPv227[T]):
                 name=name,
                 comment=comment,
                 agent_ids=agent_ids,
+                scheduler_cron_time=scheduler_cron_time,
             )
         )
 
     def modify_agent_group(
         self,
         agent_group_id: EntityID,
+        scheduler_cron_time: str,
         *,
         name: str | None = None,
         comment: str | None = None,
@@ -262,6 +266,7 @@ class GMPNext(GMPv227[T]):
         Args:
             agent_group_id: UUID of the group to modify.
             name: Optional new name for the group.
+            scheduler_cron_time: Scheduler cron to use.
             comment: Optional comment for the group.
             agent_ids: Optional list of agent UUIDs to set for the group.
 
@@ -274,6 +279,7 @@ class GMPNext(GMPv227[T]):
                 name=name,
                 comment=comment,
                 agent_ids=agent_ids,
+                scheduler_cron_time=scheduler_cron_time,
             )
         )
 

--- a/gvm/protocols/gmp/requests/next/_agent_groups.py
+++ b/gvm/protocols/gmp/requests/next/_agent_groups.py
@@ -16,6 +16,7 @@ class AgentGroups:
         cls,
         name: str,
         agent_ids: list[str],
+        scheduler_cron_time: str,
         *,
         comment: str | None = None,
     ) -> Request:
@@ -24,6 +25,7 @@ class AgentGroups:
         Args:
             name: Name of the new agent group.
             agent_ids: List of agent UUIDs to include in the group (required).
+            scheduler_cron_time: Cron-like time to schedule new agent groups (required).
             comment: Optional comment for the group.
 
         Raises:
@@ -38,9 +40,15 @@ class AgentGroups:
             raise RequiredArgument(
                 function=cls.create_agent_group.__name__, argument="agent_ids"
             )
+        if not scheduler_cron_time:
+            raise RequiredArgument(
+                function=cls.create_agent_group.__name__,
+                argument="scheduler_cron_time",
+            )
 
         cmd = XmlCommand("create_agent_group")
         cmd.add_element("name", name)
+        cmd.add_element("scheduler_cron_time", scheduler_cron_time)
 
         if comment:
             cmd.add_element("comment", comment)
@@ -76,6 +84,7 @@ class AgentGroups:
     def modify_agent_group(
         cls,
         agent_group_id: EntityID,
+        scheduler_cron_time: str,
         *,
         name: str | None = None,
         comment: str | None = None,
@@ -85,6 +94,7 @@ class AgentGroups:
 
         Args:
             agent_group_id: UUID of the group to modify.
+            scheduler_cron_time: Cron-like time to schedule the agent groups.
             name: Optional new name for the group.
             comment: Optional comment for the group.
             agent_ids: Optional list of agent UUIDs to set for the group.
@@ -98,9 +108,15 @@ class AgentGroups:
                 argument="agent_group_id",
             )
 
+        if not scheduler_cron_time:
+            raise RequiredArgument(
+                function=cls.modify_agent_group.__name__,
+                argument="scheduler_cron_time",
+            )
+
         cmd = XmlCommand("modify_agent_group")
         cmd.set_attribute("agent_group_id", str(agent_group_id))
-
+        cmd.add_element("scheduler_cron_time", scheduler_cron_time)
         if name:
             cmd.add_element("name", name)
 

--- a/tests/connections/test_debug_connection.py
+++ b/tests/connections/test_debug_connection.py
@@ -8,12 +8,12 @@ from gvm.connections import DebugConnection, GvmConnection
 from gvm.connections._connection import AbstractGvmConnection
 
 
-class TestConnection(AbstractGvmConnection):
+class DummyConnection(AbstractGvmConnection):
     def connect(self) -> None:
         pass
 
 
 class DebugConnectionTestCase(unittest.TestCase):
     def test_is_gvm_connection(self):
-        connection = DebugConnection(TestConnection())
+        connection = DebugConnection(DummyConnection())
         self.assertTrue(isinstance(connection, GvmConnection))

--- a/tests/connections/test_gvm_connection.py
+++ b/tests/connections/test_gvm_connection.py
@@ -14,7 +14,7 @@ from gvm.connections._connection import AbstractGvmConnection
 from gvm.errors import GvmError
 
 
-class TestConnection(AbstractGvmConnection):
+class DummyConnection(AbstractGvmConnection):
     def connect(self) -> None:
         pass
 
@@ -22,13 +22,13 @@ class TestConnection(AbstractGvmConnection):
 class GvmConnectionTestCase(unittest.TestCase):
     # pylint: disable=protected-access
     def test_init_no_args(self):
-        connection = TestConnection()
+        connection = DummyConnection()
 
         self.assertIsNone(connection._socket)
         self.assertEqual(connection._timeout, DEFAULT_TIMEOUT)
 
     def test_init_with_none(self):
-        connection = TestConnection(timeout=None)
+        connection = DummyConnection(timeout=None)
 
         self.assertIsNone(connection._socket)
         self.assertEqual(connection._timeout, DEFAULT_TIMEOUT)
@@ -37,7 +37,7 @@ class GvmConnectionTestCase(unittest.TestCase):
         read_mock = MagicMock()
         read_mock.return_value = None
 
-        connection = TestConnection()
+        connection = DummyConnection()
         connection._read = read_mock
 
         with self.assertRaises(GvmError, msg="Remote closed the connection"):
@@ -49,7 +49,7 @@ class GvmConnectionTestCase(unittest.TestCase):
         read_mock = MagicMock()
         read_mock.side_effect = [b"<foo>xyz<bar></bar>", b"</foo>"]
 
-        connection = TestConnection(timeout=0)
+        connection = DummyConnection(timeout=0)
         connection._read = read_mock
 
         with self.assertRaises(
@@ -58,5 +58,5 @@ class GvmConnectionTestCase(unittest.TestCase):
             connection.read()
 
     def test_is_gvm_connection(self):
-        connection = TestConnection()
+        connection = DummyConnection()
         self.assertTrue(isinstance(connection, GvmConnection))

--- a/tests/connections/test_unix_socket_connection.py
+++ b/tests/connections/test_unix_socket_connection.py
@@ -23,6 +23,15 @@ from gvm.errors import GvmError
 class DummyRequestHandler(socketserver.BaseRequestHandler):
     def handle(self):
         response = b'<gmp_response status="200" status_text="OK"/>'
+
+        self.request.settimeout(0.2)
+        try:
+            self.request.recv(16 * 1024)
+        except TimeoutError:
+            pass
+        except OSError:
+            pass
+
         self.request.sendall(response)
 
 
@@ -47,29 +56,33 @@ class UnixSocketConnectionTestCase(unittest.TestCase):
         self.server_thread.start()
 
     def tearDown(self):
-        self.socket_server.server_close()
         self.socket_server.shutdown()
         self.server_thread.join(60.0)
+        self.socket_server.server_close()
         self.socket_path.unlink(missing_ok=True)
 
     def test_unix_socket_connection_connect_read(self):
         connection = UnixSocketConnection(
             path=self.socket_name, timeout=DEFAULT_TIMEOUT
         )
+        self.addCleanup(connection.disconnect)
+
         connection.connect()
         resp = connection.read()
+
         self.assertEqual(resp, b'<gmp_response status="200" status_text="OK"/>')
-        connection.disconnect()
 
     def test_unix_socket_connection_connect_send_bytes_read(self):
         connection = UnixSocketConnection(
             path=self.socket_name, timeout=DEFAULT_TIMEOUT
         )
+        self.addCleanup(connection.disconnect)
+
         connection.connect()
         connection.send(b"<gmp/>")
         resp = connection.read()
+
         self.assertEqual(resp, b'<gmp_response status="200" status_text="OK"/>')
-        connection.disconnect()
 
     def test_unix_socket_connect_file_not_found(self):
         connection = UnixSocketConnection(path="foo", timeout=DEFAULT_TIMEOUT)

--- a/tests/connections/test_unix_socket_connection.py
+++ b/tests/connections/test_unix_socket_connection.py
@@ -27,10 +27,10 @@ class DummyRequestHandler(socketserver.BaseRequestHandler):
         self.request.settimeout(0.2)
         try:
             self.request.recv(16 * 1024)
-        except TimeoutError:
-            pass
-        except OSError:
-            pass
+        except (TimeoutError, OSError):
+            # In tests, receiving request data is optional; on timeout/socket read
+            # issues we still return the canned response to keep behavior deterministic.
+            _ = None
 
         self.request.sendall(response)
 

--- a/tests/protocols/gmpnext/entities/agent_groups/test_create_agent_group.py
+++ b/tests/protocols/gmpnext/entities/agent_groups/test_create_agent_group.py
@@ -11,11 +11,13 @@ class GmpCreateAgentGroupTestMixin:
             name="ExampleGroup",
             agent_ids=["agent-1", "agent-2"],
             comment="Sample comment",
+            scheduler_cron_time="0 */5 * * *",
         )
 
         self.connection.send.has_been_called_with(
             b"<create_agent_group>"
             b"<name>ExampleGroup</name>"
+            b"<scheduler_cron_time>0 */5 * * *</scheduler_cron_time>"
             b"<comment>Sample comment</comment>"
             b'<agents><agent id="agent-1"/><agent id="agent-2"/></agents>'
             b"</create_agent_group>"
@@ -23,18 +25,35 @@ class GmpCreateAgentGroupTestMixin:
 
     def test_create_agent_group_without_name(self):
         with self.assertRaises(RequiredArgument):
-            self.gmp.create_agent_group(name="", agent_ids=["agent-1"])
+            self.gmp.create_agent_group(
+                name="",
+                agent_ids=["agent-1"],
+                scheduler_cron_time="0 */5 * * *",
+            )
 
     def test_create_agent_group_without_agents(self):
         with self.assertRaises(RequiredArgument):
-            self.gmp.create_agent_group(name="Group", agent_ids=[])
+            self.gmp.create_agent_group(
+                name="Group", agent_ids=[], scheduler_cron_time="0 */5 * * *"
+            )
+
+    def test_create_agent_group_without_scheduler_cron_time(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.create_agent_group(
+                name="Group", agent_ids=["agent-1"], scheduler_cron_time=None
+            )
 
     def test_create_agent_group_without_comment(self):
-        self.gmp.create_agent_group(name="GroupX", agent_ids=["a1", "a2"])
+        self.gmp.create_agent_group(
+            name="GroupX",
+            agent_ids=["a1", "a2"],
+            scheduler_cron_time="0 */5 * * *",
+        )
 
         self.connection.send.has_been_called_with(
             b"<create_agent_group>"
             b"<name>GroupX</name>"
+            b"<scheduler_cron_time>0 */5 * * *</scheduler_cron_time>"
             b'<agents><agent id="a1"/><agent id="a2"/></agents>'
             b"</create_agent_group>"
         )

--- a/tests/protocols/gmpnext/entities/agent_groups/test_modify_agent_group.py
+++ b/tests/protocols/gmpnext/entities/agent_groups/test_modify_agent_group.py
@@ -11,11 +11,13 @@ class GmpModifyAgentGroupTestMixin:
             agent_group_id="group-1",
             name="NewName",
             comment="Updated comment",
+            scheduler_cron_time="0 */5 * * *",
             agent_ids=["agent-1", "agent-2"],
         )
 
         self.connection.send.has_been_called_with(
             b'<modify_agent_group agent_group_id="group-1">'
+            b"<scheduler_cron_time>0 */5 * * *</scheduler_cron_time>"
             b"<name>NewName</name>"
             b"<comment>Updated comment</comment>"
             b'<agents><agent id="agent-1"/><agent id="agent-2"/></agents>'
@@ -24,17 +26,27 @@ class GmpModifyAgentGroupTestMixin:
 
     def test_modify_agent_group_without_id(self):
         with self.assertRaises(RequiredArgument):
-            self.gmp.modify_agent_group(agent_group_id=None)
+            self.gmp.modify_agent_group(
+                agent_group_id=None, scheduler_cron_time="0 */5 * * *"
+            )
+
+    def test_modify_agent_group_without_scheduler_cron_time(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.modify_agent_group(
+                agent_group_id="group-1", scheduler_cron_time=None
+            )
 
     def test_modify_agent_group_without_name(self):
         self.gmp.modify_agent_group(
             agent_group_id="group-1",
             comment="Updated comment",
+            scheduler_cron_time="0 */5 * * *",
             agent_ids=["agent-1", "agent-2"],
         )
 
         self.connection.send.has_been_called_with(
             b'<modify_agent_group agent_group_id="group-1">'
+            b"<scheduler_cron_time>0 */5 * * *</scheduler_cron_time>"
             b"<comment>Updated comment</comment>"
             b'<agents><agent id="agent-1"/><agent id="agent-2"/></agents>'
             b"</modify_agent_group>"
@@ -44,11 +56,13 @@ class GmpModifyAgentGroupTestMixin:
         self.gmp.modify_agent_group(
             agent_group_id="group-1",
             name="NewName",
+            scheduler_cron_time="0 */5 * * *",
             agent_ids=["agent-1", "agent-2"],
         )
 
         self.connection.send.has_been_called_with(
             b'<modify_agent_group agent_group_id="group-1">'
+            b"<scheduler_cron_time>0 */5 * * *</scheduler_cron_time>"
             b"<name>NewName</name>"
             b'<agents><agent id="agent-1"/><agent id="agent-2"/></agents>'
             b"</modify_agent_group>"
@@ -59,10 +73,12 @@ class GmpModifyAgentGroupTestMixin:
             agent_group_id="group-1",
             name="NewName",
             comment="Updated comment",
+            scheduler_cron_time="0 */5 * * *",
         )
 
         self.connection.send.has_been_called_with(
             b'<modify_agent_group agent_group_id="group-1">'
+            b"<scheduler_cron_time>0 */5 * * *</scheduler_cron_time>"
             b"<name>NewName</name>"
             b"<comment>Updated comment</comment>"
             b"</modify_agent_group>"


### PR DESCRIPTION
## What

Added the mandatory `scheduler_cron_time` parameter to create and modify agent group commands and updated the related tests.

## Why

This is needed because `scheduler_cron_time` is now required for agent group comments.


## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


