### PR TITLE
add: support origin URL for agent installer instructions

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -65,17 +65,21 @@ class GMPNext(GMPv227[T]):
         *,
         scanner_id: EntityID,
         language_type: AgentInstallerInstructionLanguageType,
+        origin_url: str,
     ) -> T:
         """Request an agent installer instruction.
 
         Args:
             scanner_id: UUID of the Agent controller to get the installer instruction for.
             language_type: Language of the installer instruction.
+            origin_url: Origin URL used to generate the executable agent
+                installation command.
         """
         return self._send_request_and_transform_response(
             AgentInstallerInstructions.get_agent_installer_instruction(
                 scanner_id=scanner_id,
                 language_type=language_type,
+                origin_url=origin_url,
             )
         )
 

--- a/gvm/protocols/gmp/requests/next/_agent_installer_instructions.py
+++ b/gvm/protocols/gmp/requests/next/_agent_installer_instructions.py
@@ -17,12 +17,19 @@ class AgentInstallerInstructions:
         cls,
         scanner_id: EntityID,
         language_type: AgentInstallerInstructionLanguageType,
+        origin_url: str,
     ) -> Request:
         """Request an agent installer instruction.
 
         Args:
             scanner_id: UUID of the Agent controller to get the installer instruction for.
             language_type: Language of the installer instruction.
+            origin_url: Origin URL used to generate the executable agent
+                installation command.
+
+        Raises:
+            RequiredArgument: If scanner_id, language_type, or origin_url is
+                missing.
         """
         if not scanner_id:
             raise RequiredArgument(
@@ -36,8 +43,15 @@ class AgentInstallerInstructions:
                 argument="language_type",
             )
 
+        if not origin_url:
+            raise RequiredArgument(
+                function=cls.get_agent_installer_instruction.__name__,
+                argument="origin_url",
+            )
+
         cmd = XmlCommand("get_agent_installer_instruction")
         cmd.set_attribute("scanner_id", str(scanner_id))
         cmd.set_attribute("language", language_type.value)
+        cmd.set_attribute("origin_url", origin_url)
 
         return cmd

--- a/tests/protocols/gmpnext/entities/agent_installer_instructions/test_get_aget_installer_instruction.py
+++ b/tests/protocols/gmpnext/entities/agent_installer_instructions/test_get_aget_installer_instruction.py
@@ -14,20 +14,42 @@ class GmpGetAgentInstallerInstructionTestMixin:
         self.gmp.get_agent_installer_instruction(
             scanner_id="scanner1",
             language_type=AgentInstallerInstructionLanguageType.EN,
+            origin_url="https://example.com",
         )
 
         self.connection.send.has_been_called_with(
-            b'<get_agent_installer_instruction scanner_id="scanner1" language="en"/>'
+            b"<get_agent_installer_instruction"
+            b' scanner_id="scanner1"'
+            b' language="en"'
+            b' origin_url="https://example.com"/>'
         )
 
     def test_get_agent_installer_instruction_de(self):
         self.gmp.get_agent_installer_instruction(
             scanner_id="scanner1",
             language_type=AgentInstallerInstructionLanguageType.DE,
+            origin_url="https://example.com",
         )
 
         self.connection.send.has_been_called_with(
-            b'<get_agent_installer_instruction scanner_id="scanner1" language="de"/>'
+            b"<get_agent_installer_instruction"
+            b' scanner_id="scanner1"'
+            b' language="de"'
+            b' origin_url="https://example.com"/>'
+        )
+
+    def test_get_agent_installer_instruction_escapes_origin_url(self):
+        self.gmp.get_agent_installer_instruction(
+            scanner_id="scanner1",
+            language_type=AgentInstallerInstructionLanguageType.EN,
+            origin_url="https://example.com/path?foo=bar&value=test",
+        )
+
+        self.connection.send.has_been_called_with(
+            b"<get_agent_installer_instruction"
+            b' scanner_id="scanner1"'
+            b' language="en"'
+            b' origin_url="https://example.com/path?foo=bar&amp;value=test"/>'
         )
 
     def test_get_agent_installer_instruction_without_scanner_id(self):
@@ -35,12 +57,14 @@ class GmpGetAgentInstallerInstructionTestMixin:
             self.gmp.get_agent_installer_instruction(
                 scanner_id=None,
                 language_type=AgentInstallerInstructionLanguageType.EN,
+                origin_url="https://example.com",
             )
 
         with self.assertRaises(RequiredArgument):
             self.gmp.get_agent_installer_instruction(
                 scanner_id="",
                 language_type=AgentInstallerInstructionLanguageType.EN,
+                origin_url="https://example.com",
             )
 
     def test_get_agent_installer_instruction_without_language_type(self):
@@ -48,10 +72,27 @@ class GmpGetAgentInstallerInstructionTestMixin:
             self.gmp.get_agent_installer_instruction(
                 scanner_id="scanner1",
                 language_type=None,
+                origin_url="https://example.com",
             )
 
         with self.assertRaises(RequiredArgument):
             self.gmp.get_agent_installer_instruction(
                 scanner_id="scanner1",
                 language_type="",
+                origin_url="https://example.com",
+            )
+
+    def test_get_agent_installer_instruction_without_origin_url(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_agent_installer_instruction(
+                scanner_id="scanner1",
+                language_type=AgentInstallerInstructionLanguageType.EN,
+                origin_url=None,
+            )
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_agent_installer_instruction(
+                scanner_id="scanner1",
+                language_type=AgentInstallerInstructionLanguageType.EN,
+                origin_url="",
             )

--- a/uv.lock
+++ b/uv.lock
@@ -1267,7 +1267,7 @@ wheels = [
 
 [[package]]
 name = "python-gvm"
-version = "27.3.1.dev1"
+version = "27.3.2.dev1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx", extra = ["http2"] },


### PR DESCRIPTION
## What

Add the required `origin_url` argument to agent installer instruction requests and update the tests.

## Why

The origin URL is needed to generate the correct executable agent installation command.


## References

GEA-1848

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


