### PR TITLE
add: add get_scan_report request support

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -30,6 +30,7 @@ from .requests.next import (
     ReportPorts,
     ReportTlsCertificates,
     ReportVulnerabilities,
+    ScanReports,
     Targets,
     Tasks,
     WebApplicationTargets,
@@ -1640,5 +1641,33 @@ class GMPNext(GMPv227[T]):
                 filter_id=filter_id,
                 trash=trash,
                 tasks=tasks,
+            )
+        )
+
+    def get_scan_report(
+        self,
+        scan_report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+    ) -> T:
+        """ "Request a structured summary of a single scan report.
+
+        Args:
+            scan_report_id: UUID of an existing scan report.
+            filter_string: Filter term to apply to the report results.
+            filter_id: UUID of a saved filter to apply to the report results.
+
+        Returns:
+            A request for the get_scan_report GMP command.
+
+        Raises:
+            RequiredArgument: If scan_report_id is not provided.
+        """
+        return self._send_request_and_transform_response(
+            ScanReports.get_scan_report(
+                scan_report_id=scan_report_id,
+                filter_string=filter_string,
+                filter_id=filter_id,
             )
         )

--- a/gvm/protocols/gmp/requests/next/__init__.py
+++ b/gvm/protocols/gmp/requests/next/__init__.py
@@ -44,6 +44,7 @@ from gvm.protocols.gmp.requests.next._report_tls_certificates import (
 from gvm.protocols.gmp.requests.next._report_vulnerabilities import (
     ReportVulnerabilities,
 )
+from gvm.protocols.gmp.requests.next._scan_report import ScanReports
 from gvm.protocols.gmp.requests.next._targets import AliveTest, Targets
 from gvm.protocols.gmp.requests.next._tasks import Tasks
 from gvm.protocols.gmp.requests.next._web_application_targets import (
@@ -184,6 +185,7 @@ __all__ = (
     "Results",
     "Roles",
     "ScanConfigs",
+    "ScanReports",
     "ScannerType",
     "Scanners",
     "Schedules",

--- a/gvm/protocols/gmp/requests/next/_scan_report.py
+++ b/gvm/protocols/gmp/requests/next/_scan_report.py
@@ -1,0 +1,39 @@
+from gvm.errors import RequiredArgument
+from gvm.protocols.core import Request
+from gvm.protocols.gmp.requests import EntityID
+from gvm.xml import XmlCommand
+
+
+class ScanReports:
+    @classmethod
+    def get_scan_report(
+        cls,
+        scan_report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+    ) -> Request:
+        """Request a structured summary of a single scan report.
+
+        Args:
+            scan_report_id: UUID of an existing scan report.
+            filter_string: Filter term to apply to the report results.
+            filter_id: UUID of a saved filter to apply to the report results.
+
+        Returns:
+            A request for the get_scan_report GMP command.
+
+        Raises:
+            RequiredArgument: If scan_report_id is not provided.
+        """
+        if not scan_report_id:
+            raise RequiredArgument(
+                function=cls.get_scan_report.__name__,
+                argument="scan_report_id",
+            )
+
+        cmd = XmlCommand("get_scan_report")
+        cmd.set_attribute("scan_report_id", str(scan_report_id))
+        cmd.add_filter(filter_string, filter_id)
+
+        return cmd

--- a/tests/protocols/gmpnext/entities/scan_reports/__init__.py
+++ b/tests/protocols/gmpnext/entities/scan_reports/__init__.py
@@ -1,0 +1,10 @@
+#  SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+#  SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from .test_get_scan_report import (
+    GmpGetScanReportTestMixin,
+)
+
+__all__ = ("GmpGetScanReportTestMixin",)

--- a/tests/protocols/gmpnext/entities/scan_reports/test_get_scan_report.py
+++ b/tests/protocols/gmpnext/entities/scan_reports/test_get_scan_report.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gvm.errors import RequiredArgument
+
+
+class GmpGetScanReportTestMixin:
+    def test_get_scan_report_without_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_scan_report(None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_scan_report("")
+
+    def test_get_scan_report_with_id(self):
+        self.gmp.get_scan_report(scan_report_id="r1")
+
+        self.connection.send.has_been_called_with(
+            b'<get_scan_report scan_report_id="r1"/>'
+        )
+
+    def test_get_scan_report_with_filter_string(self):
+        self.gmp.get_scan_report(
+            scan_report_id="r1",
+            filter_string="name=foo",
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_scan_report scan_report_id="r1" filter="name=foo"/>'
+        )
+
+    def test_get_scan_report_with_filter_id(self):
+        self.gmp.get_scan_report(
+            scan_report_id="r1",
+            filter_id="f1",
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_scan_report scan_report_id="r1" filt_id="f1"/>'
+        )
+
+    def test_get_scan_report_with_filter_string_and_filter_id(self):
+        self.gmp.get_scan_report(
+            scan_report_id="r1",
+            filter_string="name=foo",
+            filter_id="f1",
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_scan_report scan_report_id="r1" '
+            b'filter="name=foo" filt_id="f1"/>'
+        )

--- a/tests/protocols/gmpnext/entities/test_scan_reports.py
+++ b/tests/protocols/gmpnext/entities/test_scan_reports.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from ...gmpnext import GMPTestCase
+from .scan_reports.test_get_scan_report import (
+    GmpGetScanReportTestMixin,
+)
+
+
+class GmpGetScanReportTestCase(GmpGetScanReportTestMixin, GMPTestCase):
+    pass


### PR DESCRIPTION
## What

- Add `get_scan_report` request support
- Add validation for `scan_report_id`
- Support filter strings and saved filter IDs
- Add tests for request generation and missing IDs

## Why

- Allow python-gvm clients to use the new `get_scan_report` GMP command
- Keep scan report retrieval consistent with the gvmd implementation

## References

GEA-1949

## Checklist

- [x] Tests


