### PR TITLE
add: add get_audit_report request support

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -16,6 +16,7 @@ from .requests.next import (
     AgentInstallerInstructions,
     Agents,
     AliveTest,
+    AuditReport,
     Credentials,
     CredentialStoreCredentialType,
     CredentialStores,
@@ -1667,6 +1668,34 @@ class GMPNext(GMPv227[T]):
         return self._send_request_and_transform_response(
             ScanReports.get_scan_report(
                 scan_report_id=scan_report_id,
+                filter_string=filter_string,
+                filter_id=filter_id,
+            )
+        )
+
+    def get_audit_report(
+        self,
+        audit_report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+    ) -> T:
+        """Request a structured summary of a single audit report.
+
+        Args:
+            audit_report_id: UUID of an existing audit report.
+            filter_string: Filter term to apply to the report results.
+            filter_id: UUID of a saved filter to apply to the report results.
+
+        Returns:
+            A request for the get_audit_report GMP command.
+
+        Raises:
+            RequiredArgument: If audit_report_id is not provided.
+        """
+        return self._send_request_and_transform_response(
+            AuditReport.get_audit_report(
+                audit_report_id=audit_report_id,
                 filter_string=filter_string,
                 filter_id=filter_id,
             )

--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -38,6 +38,7 @@ from .requests.next import (
 )
 from .requests.v224 import AliveTest as AliveTestV224
 from .requests.v224 import HostsOrdering
+from .requests.v226 import ReportFormatType
 
 
 class GMPNext(GMPv227[T]):
@@ -1673,7 +1674,7 @@ class GMPNext(GMPv227[T]):
             )
         )
 
-    def get_audit_report(
+    def get_audit_report(  # type: ignore[override]
         self,
         audit_report_id: EntityID,
         *,
@@ -1699,4 +1700,31 @@ class GMPNext(GMPv227[T]):
                 filter_string=filter_string,
                 filter_id=filter_id,
             )
+        )
+
+    def get_audit_report_legacy(
+        self,
+        report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+        delta_report_id: EntityID | None = None,
+        report_format_id: str | ReportFormatType | None = None,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> T:
+        """Request an audit report using the legacy command.
+
+        Deprecated:
+            Use ``get_audit_report`` instead. This method will be removed
+            in the next major release.
+        """
+        return super().get_audit_report(
+            report_id,
+            filter_string=filter_string,
+            filter_id=filter_id,
+            delta_report_id=delta_report_id,
+            report_format_id=report_format_id,
+            ignore_pagination=ignore_pagination,
+            details=details,
         )

--- a/gvm/protocols/gmp/requests/next/__init__.py
+++ b/gvm/protocols/gmp/requests/next/__init__.py
@@ -8,6 +8,7 @@ from gvm.protocols.gmp.requests.next._agent_installer_instructions import (
     AgentInstallerInstructions,
 )
 from gvm.protocols.gmp.requests.next._agents import Agents
+from gvm.protocols.gmp.requests.next._audit_report import AuditReport
 from gvm.protocols.gmp.requests.next._credential_stores import CredentialStores
 from gvm.protocols.gmp.requests.next._credentials import (
     Credentials,
@@ -131,6 +132,7 @@ __all__ = (
     "AlertMethod",
     "Alerts",
     "AliveTest",
+    "AuditReport",
     "AuditReports",
     "Audits",
     "Authentication",

--- a/gvm/protocols/gmp/requests/next/_audit_report.py
+++ b/gvm/protocols/gmp/requests/next/_audit_report.py
@@ -1,0 +1,39 @@
+from gvm.errors import RequiredArgument
+from gvm.protocols.core import Request
+from gvm.protocols.gmp.requests import EntityID
+from gvm.xml import XmlCommand
+
+
+class AuditReport:
+    @classmethod
+    def get_audit_report(
+        cls,
+        audit_report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+    ) -> Request:
+        """Request a structured summary of a single audit report.
+
+        Args:
+            audit_report_id: UUID of an existing audit report.
+            filter_string: Filter term to apply to the report results.
+            filter_id: UUID of a saved filter to apply to the report results.
+
+        Returns:
+            A request for the get_audit_report GMP command.
+
+        Raises:
+            RequiredArgument: If audit_report_id is not provided.
+        """
+        if not audit_report_id:
+            raise RequiredArgument(
+                function=cls.get_audit_report.__name__,
+                argument="audit_report_id",
+            )
+
+        cmd = XmlCommand("get_audit_report")
+        cmd.set_attribute("audit_report_id", str(audit_report_id))
+        cmd.add_filter(filter_string, filter_id)
+
+        return cmd

--- a/tests/protocols/gmpnext/entities/audit_report/__init__.py
+++ b/tests/protocols/gmpnext/entities/audit_report/__init__.py
@@ -1,0 +1,10 @@
+#  SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+#  SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from .test_get_audit_report import (
+    GmpGetAuditReportTestMixin,
+)
+
+__all__ = ("GmpGetAuditReportTestMixin",)

--- a/tests/protocols/gmpnext/entities/audit_report/__init__.py
+++ b/tests/protocols/gmpnext/entities/audit_report/__init__.py
@@ -6,5 +6,11 @@
 from .test_get_audit_report import (
     GmpGetAuditReportTestMixin,
 )
+from .test_get_audit_report_legacy import (
+    GmpGetAuditReportLegacyTestMixin,
+)
 
-__all__ = ("GmpGetAuditReportTestMixin",)
+__all__ = (
+    "GmpGetAuditReportLegacyTestMixin",
+    "GmpGetAuditReportTestMixin",
+)

--- a/tests/protocols/gmpnext/entities/audit_report/test_get_audit_report.py
+++ b/tests/protocols/gmpnext/entities/audit_report/test_get_audit_report.py
@@ -1,0 +1,54 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gvm.errors import RequiredArgument
+
+
+class GmpGetAuditReportTestMixin:
+    def test_get_audit_report_without_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_audit_report(None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_audit_report("")
+
+    def test_get_audit_report_with_id(self):
+        self.gmp.get_audit_report(audit_report_id="r1")
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report audit_report_id="r1"/>'
+        )
+
+    def test_get_audit_report_with_filter_string(self):
+        self.gmp.get_audit_report(
+            audit_report_id="r1",
+            filter_string="name=foo",
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report audit_report_id="r1" filter="name=foo"/>'
+        )
+
+    def test_get_audit_report_with_filter_id(self):
+        self.gmp.get_audit_report(
+            audit_report_id="r1",
+            filter_id="f1",
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report audit_report_id="r1" filt_id="f1"/>'
+        )
+
+    def test_get_audit_report_with_filter_string_and_filter_id(self):
+        self.gmp.get_audit_report(
+            audit_report_id="r1",
+            filter_string="name=foo",
+            filter_id="f1",
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report audit_report_id="r1" '
+            b'filter="name=foo" filt_id="f1"/>'
+        )

--- a/tests/protocols/gmpnext/entities/audit_report/test_get_audit_report_legacy.py
+++ b/tests/protocols/gmpnext/entities/audit_report/test_get_audit_report_legacy.py
@@ -1,0 +1,85 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gvm.errors import RequiredArgument
+from gvm.protocols.gmp.requests.v226 import ReportFormatType
+
+
+class GmpGetAuditReportLegacyTestMixin:
+    def test_get_audit_report_legacy_without_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_audit_report_legacy(None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_audit_report_legacy("")
+
+    def test_get_audit_report_legacy_with_filter_string(self):
+        self.gmp.get_audit_report_legacy(
+            report_id="r1", filter_string="name=foo"
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_reports report_id="r1" usage_type="audit" filter="name=foo" details="1"/>'
+        )
+
+    def test_get_audit_report_legacy_with_filter_id(self):
+        self.gmp.get_audit_report_legacy(report_id="r1", filter_id="f1")
+
+        self.connection.send.has_been_called_with(
+            b'<get_reports report_id="r1" usage_type="audit" filt_id="f1" details="1"/>'
+        )
+
+    def test_get_audit_report_legacy_with_report_format_id(self):
+        self.gmp.get_audit_report_legacy(report_id="r1", report_format_id="bar")
+
+        self.connection.send.has_been_called_with(
+            b'<get_reports report_id="r1" usage_type="audit" format_id="bar" details="1"/>'
+        )
+
+    def test_get_audit_report_legacy_with_report_format_type(self):
+        self.gmp.get_audit_report_legacy(
+            report_id="r1", report_format_id=ReportFormatType.TXT
+        )
+        report_format_id = ReportFormatType.from_string("txt").value
+
+        self.connection.send.has_been_called_with(
+            '<get_reports report_id="r1" usage_type="audit" format_id='
+            f'"{report_format_id}" details="1"/>'.encode()
+        )
+
+    def test_get_audit_report_legacy_with_delta_report_id(self):
+        self.gmp.get_audit_report_legacy(report_id="r1", delta_report_id="r2")
+
+        self.connection.send.has_been_called_with(
+            b'<get_reports report_id="r1" usage_type="audit" delta_report_id="r2" details="1"/>'
+        )
+
+    def test_get_audit_report_legacy_with_ignore_pagination(self):
+        self.gmp.get_audit_report_legacy(report_id="r1", ignore_pagination=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_reports report_id="r1" usage_type="audit" ignore_pagination="1" details="1"/>'
+        )
+
+        self.gmp.get_audit_report_legacy(
+            report_id="r1", ignore_pagination=False
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_reports report_id="r1" usage_type="audit" ignore_pagination="0" details="1"/>'
+        )
+
+    def test_get_audit_report_legacy_with_details(self):
+        self.gmp.get_audit_report_legacy(report_id="r1", details=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_reports report_id="r1" usage_type="audit" details="1"/>'
+        )
+
+        self.gmp.get_audit_report_legacy(report_id="r1", details=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_reports report_id="r1" usage_type="audit" details="0"/>'
+        )

--- a/tests/protocols/gmpnext/entities/test_audit_report.py
+++ b/tests/protocols/gmpnext/entities/test_audit_report.py
@@ -4,10 +4,17 @@
 #
 
 from ...gmpnext import GMPTestCase
-from .audit_report.test_get_audit_report import (
+from ...gmpnext.entities.audit_report import (
+    GmpGetAuditReportLegacyTestMixin,
     GmpGetAuditReportTestMixin,
 )
 
 
 class GmpGetAuditReportTestCase(GmpGetAuditReportTestMixin, GMPTestCase):
+    pass
+
+
+class GmpGetAuditReportLegacyTestCase(
+    GmpGetAuditReportLegacyTestMixin, GMPTestCase
+):
     pass

--- a/tests/protocols/gmpnext/entities/test_audit_report.py
+++ b/tests/protocols/gmpnext/entities/test_audit_report.py
@@ -1,0 +1,13 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from ...gmpnext import GMPTestCase
+from .audit_report.test_get_audit_report import (
+    GmpGetAuditReportTestMixin,
+)
+
+
+class GmpGetAuditReportTestCase(GmpGetAuditReportTestMixin, GMPTestCase):
+    pass


### PR DESCRIPTION
## What

- Add `get_audit_report` request support
- Add validation for `audit_report_id`
- Support filter strings and saved filter IDs
- Add tests for request generation and missing IDs

## Why

- Allow python-gvm clients to use the new `get_audit_report` GMP command
- Keep audit report retrieval consistent with the gvmd implementation

## References

GEA-1962

## Checklist

- [x] Tests


