### PR TITLE
add: add get_audit_report_hosts request support

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -1092,6 +1092,36 @@ class GMPNext(GMPv227[T]):
             )
         )
 
+    def get_audit_report_hosts(
+        self,
+        report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> T:
+        """Request hosts of a single audit report.
+
+        Args:
+            report_id: UUID of an existing report.
+            filter_string: Filter term to use to filter results in the report
+            filter_id: UUID of filter to use to filter results in the report
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report host information details.
+                Defaults to True.
+        """
+        return self._send_request_and_transform_response(
+            ReportHosts.get_audit_report_hosts(
+                report_id=report_id,
+                filter_string=filter_string,
+                filter_id=filter_id,
+                ignore_pagination=ignore_pagination,
+                details=details,
+            )
+        )
+
     def get_report_operating_systems(
         self,
         report_id: EntityID,

--- a/gvm/protocols/gmp/requests/next/_report_hosts.py
+++ b/gvm/protocols/gmp/requests/next/_report_hosts.py
@@ -44,3 +44,42 @@ class ReportHosts:
         cmd.set_attribute("details", to_bool(details))
 
         return cmd
+
+    @classmethod
+    def get_audit_report_hosts(
+        cls,
+        report_id: EntityID,
+        *,
+        filter_string: str | None = None,
+        filter_id: str | None = None,
+        ignore_pagination: bool | None = None,
+        details: bool | None = True,
+    ) -> Request:
+        """Request hosts of a single audit report.
+
+        Args:
+            report_id: UUID of an existing report.
+            filter_string: Filter term to use to filter results in the report
+            filter_id: UUID of filter to use to filter results in the report
+            ignore_pagination: Whether to ignore the filter terms "first" and
+                "rows".
+            details: Request additional report host information details.
+                Defaults to True.
+        """
+        cmd = XmlCommand("get_audit_report_hosts")
+
+        if not report_id:
+            raise RequiredArgument(
+                function=cls.get_report_hosts.__name__, argument="report_id"
+            )
+
+        cmd.set_attribute("report_id", str(report_id))
+
+        cmd.add_filter(filter_string, filter_id)
+
+        if ignore_pagination is not None:
+            cmd.set_attribute("ignore_pagination", to_bool(ignore_pagination))
+
+        cmd.set_attribute("details", to_bool(details))
+
+        return cmd

--- a/tests/protocols/gmpnext/entities/report_hosts/test_get_audit_report_hosts.py
+++ b/tests/protocols/gmpnext/entities/report_hosts/test_get_audit_report_hosts.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from gvm.errors import RequiredArgument
+
+
+class GmpGetAuditReportHostsTestMixin:
+    def test_get_audit_report_hosts_without_id(self):
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_audit_report_hosts(None)
+
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_audit_report_hosts("")
+
+    def test_get_audit_report_hosts_with_filter_string(self):
+        self.gmp.get_audit_report_hosts(
+            report_id="r1", filter_string="name=foo"
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report_hosts report_id="r1" filter="name=foo" details="1"/>'
+        )
+
+    def test_get_audit_report_hosts_with_filter_id(self):
+        self.gmp.get_audit_report_hosts(report_id="r1", filter_id="f1")
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report_hosts report_id="r1" filt_id="f1" details="1"/>'
+        )
+
+    def test_get_audit_report_hosts_with_ignore_pagination(self):
+        self.gmp.get_audit_report_hosts(report_id="r1", ignore_pagination=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report_hosts report_id="r1" ignore_pagination="1" details="1"/>'
+        )
+
+        self.gmp.get_audit_report_hosts(report_id="r1", ignore_pagination=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report_hosts report_id="r1" ignore_pagination="0" details="1"/>'
+        )
+
+    def test_get_audit_report_hosts_with_details(self):
+        self.gmp.get_audit_report_hosts(report_id="r1", details=True)
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report_hosts report_id="r1" details="1"/>'
+        )
+
+        self.gmp.get_audit_report_hosts(report_id="r1", details=False)
+
+        self.connection.send.has_been_called_with(
+            b'<get_audit_report_hosts report_id="r1" details="0"/>'
+        )

--- a/tests/protocols/gmpnext/entities/test_report_hosts.py
+++ b/tests/protocols/gmpnext/entities/test_report_hosts.py
@@ -4,10 +4,19 @@
 #
 
 from ...gmpnext import GMPTestCase
+from .report_hosts.test_get_audit_report_hosts import (
+    GmpGetAuditReportHostsTestMixin,
+)
 from .report_hosts.test_get_report_hosts import (
     GmpGetReportHostsTestMixin,
 )
 
 
 class GmpGetReportHostsTestCase(GmpGetReportHostsTestMixin, GMPTestCase):
+    pass
+
+
+class GmpGetAuditReportHostsTestCase(
+    GmpGetAuditReportHostsTestMixin, GMPTestCase
+):
     pass


### PR DESCRIPTION
## What

- Add `get_audit_report_hosts` request support
- Add tests for request generation and missing IDs

## Why

- Allow python-gvm clients to use the new `get_audit_report_hosts` GMP command
- Keep audit report hosts retrieval consistent with the gvmd implementation

## References

GEA-1967

## Checklist

- [x] Tests


