### PR TITLE
Update dependabot config and pin actions to commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,5 +12,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "actions/*"
+    ignore:
+      - dependency-name: "greenbone/actions"
+        update-types:
+          - "version-update:semver-minor"
+          - "version-update:semver-patch"
     commit-message:
       prefix: "Deps"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,10 +32,10 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6
         with:
           languages: ${{ matrix.language }}
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@5595ccaf912efad79be6eef63a5619ff05969be3 # v4.37.6


### PR DESCRIPTION


## What

Update dependabot config and pin actions to commits

## Why

Only update greenbone actions for major updates because we trust these tags and don't want to get PRs for each bugfix or minor releases.

Also group updates for github's native actions in one PR to allow for less required reviews.

Pin actions to commits for improved security. Git tags can be overridden easily. Hashes not.
