### PR TITLE
Change: Set mTLS as default and support HTTP by an explicit flag.

### DIFF
--- a/gvm/protocols/http/openvasd/_client.py
+++ b/gvm/protocols/http/openvasd/_client.py
@@ -31,7 +31,7 @@ def create_openvasd_http_client(
     """
     Create a `httpx.Client` configured for the OpenVASD HTTP API.
 
-    mTLS is used by default. Set `insecure_http=True` to use plain HTTP without SSL verification.
+    mTLS is used by default. Set `insecure_http=True` to use plain HTTP.
     In this case, an API key can be used for authorization.
 
     Args:
@@ -44,9 +44,9 @@ def create_openvasd_http_client(
         port: The port to connect to (default: 3000).
 
     Behavior:
-        - If `insecure_http=True`, `verify` is set to False (insecure), and HTTP is used instead of HTTPS.
+        - If `insecure_http=True`, HTTP is used instead of HTTPS.
             An API key can be used for authorization.
-        - If `insecure_http=False` (default), HTTPs with mTLS is used.
+        - If `insecure_http=False` (default), HTTPS with mTLS is used.
           Both `server_ca_path` and `client_cert_paths` are required.
 
     Raises:
@@ -54,40 +54,40 @@ def create_openvasd_http_client(
             `server_ca_path` or `client_cert_paths` is missing.
     """
     headers = {}
-
-    context: ssl.SSLContext | None = None
-    protocol = "http" if insecure_http else "https"
-    verify: bool | ssl.SSLContext = False if insecure_http else True
-
-    if not insecure_http:
-        if not server_ca_path or not client_cert_paths:
-            raise ValueError(
-                "Both server_ca_path and client_cert_paths must be provided "
-                "when insecure_http is False."
-            )
-        # Prepare mTLS SSL context
-        context = ssl.create_default_context(
-            ssl.Purpose.SERVER_AUTH, cafile=server_ca_path
-        )
-        if isinstance(client_cert_paths, tuple):
-            context.load_cert_chain(
-                certfile=client_cert_paths[0], keyfile=client_cert_paths[1]
-            )
-        else:
-            context.load_cert_chain(certfile=client_cert_paths)
-
-        context.check_hostname = False
-        context.verify_mode = ssl.CERT_REQUIRED
-        verify = context
     if api_key:
         headers["X-API-KEY"] = api_key
 
-    base_url = f"{protocol}://{host_name}:{port}"
+    if insecure_http:
+        return Client(
+            base_url=f"http://{host_name}:{port}",
+            headers=headers,
+            http2=True,
+            timeout=10.0,
+        )
+
+    if not server_ca_path or not client_cert_paths:
+        raise ValueError(
+            "Both server_ca_path and client_cert_paths must be provided "
+            "when insecure_http is False."
+        )
+    # Prepare mTLS SSL context
+    context = ssl.create_default_context(
+        ssl.Purpose.SERVER_AUTH, cafile=server_ca_path
+    )
+    if isinstance(client_cert_paths, tuple):
+        context.load_cert_chain(
+            certfile=client_cert_paths[0], keyfile=client_cert_paths[1]
+        )
+    else:
+        context.load_cert_chain(certfile=client_cert_paths)
+
+    context.check_hostname = False
+    context.verify_mode = ssl.CERT_REQUIRED
 
     return Client(
-        base_url=base_url,
+        base_url=f"https://{host_name}:{port}",
         headers=headers,
-        verify=verify,
+        verify=context,
         http2=True,
         timeout=10.0,
     )

--- a/gvm/protocols/http/openvasd/_client.py
+++ b/gvm/protocols/http/openvasd/_client.py
@@ -3,7 +3,10 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 """
-http client for initializing a connection to the openvasd HTTP API using optional mTLS authentication.
+http client for initializing a connection to the openvasd HTTP API.
+
+HTTPS with mTLS is used by default. Plain HTTP can be enabled explicitly
+with `insecure_http=True`.
 """
 
 import ssl
@@ -22,11 +25,14 @@ def create_openvasd_http_client(
     client_cert_paths: StrOrPathLike
     | tuple[StrOrPathLike, StrOrPathLike]
     | None = None,
+    insecure_http: bool = False,
     port: int = 3000,
 ) -> Client:
     """
-    Create a `httpx.Client` configured for mTLS-secured or API KEY access
-    to an openvasd HTTP API instance.
+    Create a `httpx.Client` configured for the OpenVASD HTTP API.
+
+    mTLS is used by default. Set `insecure_http=True` to use plain HTTP without SSL verification.
+    In this case, an API key can be used for authorization.
 
     Args:
         host_name: Hostname or IP of the OpenVASD server (e.g., "localhost").
@@ -34,20 +40,32 @@ def create_openvasd_http_client(
         server_ca_path: Path to the server's CA certificate (for verifying the server).
         client_cert_paths: Path to the client certificate (str) or a tuple of
                             (cert_path, key_path) for mTLS authentication.
+        insecure_http: If True, disables SSL verification and uses HTTP instead of HTTPS.
         port: The port to connect to (default: 3000).
 
     Behavior:
-        - If both `server_ca_path` and `client_cert_paths` are set, an mTLS connection
-            is established using an SSLContext.
-        - If not, `verify` is set to False (insecure), and HTTP is used instead of HTTPS.
-            HTTP connection needs api_key for authorization.
+        - If `insecure_http=True`, `verify` is set to False (insecure), and HTTP is used instead of HTTPS.
+            An API key can be used for authorization.
+        - If `insecure_http=False` (default), HTTPs with mTLS is used.
+          Both `server_ca_path` and `client_cert_paths` are required.
+
+    Raises:
+        ValueError: If `insecure_http=False` and either
+            `server_ca_path` or `client_cert_paths` is missing.
     """
     headers = {}
 
     context: ssl.SSLContext | None = None
+    protocol = "http" if insecure_http else "https"
+    verify: bool | ssl.SSLContext = False if insecure_http else True
 
-    # Prepare mTLS SSL context if needed
-    if client_cert_paths and server_ca_path:
+    if not insecure_http:
+        if not server_ca_path or not client_cert_paths:
+            raise ValueError(
+                "Both server_ca_path and client_cert_paths must be provided "
+                "when insecure_http is False."
+            )
+        # Prepare mTLS SSL context
         context = ssl.create_default_context(
             ssl.Purpose.SERVER_AUTH, cafile=server_ca_path
         )
@@ -60,14 +78,10 @@ def create_openvasd_http_client(
 
         context.check_hostname = False
         context.verify_mode = ssl.CERT_REQUIRED
-
-    # Set verify based on context presence
-    verify: bool | ssl.SSLContext = context if context else False
-
+        verify = context
     if api_key:
         headers["X-API-KEY"] = api_key
 
-    protocol = "https" if context else "http"
     base_url = f"{protocol}://{host_name}:{port}"
 
     return Client(

--- a/gvm/protocols/http/openvasd/_openvasd1.py
+++ b/gvm/protocols/http/openvasd/_openvasd1.py
@@ -37,6 +37,7 @@ class OpenvasdHttpAPIv1:
         client_cert_paths: StrOrPathLike
         | tuple[StrOrPathLike, StrOrPathLike]
         | None = None,
+        insecure_http: bool = False,
         suppress_exceptions: bool = False,
     ):
         """
@@ -48,6 +49,7 @@ class OpenvasdHttpAPIv1:
             api_key: Optional API key to be used for authentication.
             server_ca_path: Path to the server CA certificate (for HTTPS/mTLS).
             client_cert_paths: Path to client certificate or (cert, key) tuple for mTLS.
+            insecure_http: If True, use HTTP instead of HTTPS and disable certificate verification.
             suppress_exceptions: If True, suppress exceptions and return structured error
                 responses. Default is False, which means exceptions will be raised.
         """
@@ -57,6 +59,7 @@ class OpenvasdHttpAPIv1:
             api_key=api_key,
             server_ca_path=server_ca_path,
             client_cert_paths=client_cert_paths,
+            insecure_http=insecure_http,
         )
 
         # Sub-API modules

--- a/tests/protocols/http/openvasd/test_client.py
+++ b/tests/protocols/http/openvasd/test_client.py
@@ -11,21 +11,31 @@ from gvm.protocols.http.openvasd._client import create_openvasd_http_client
 
 class TestOpenvasdClient(unittest.TestCase):
     @patch("gvm.protocols.http.openvasd._client.Client")
-    def test_init_without_tls_or_api_key(self, mock_httpx_client):
-        create_openvasd_http_client("localhost")
+    @patch("gvm.protocols.http.openvasd._client.ssl.create_default_context")
+    def test_init_without_tls_or_api_key(
+        self, mock_ssl_ctx_factory, mock_httpx_client
+    ):
+        create_openvasd_http_client("localhost", insecure_http=True)
         mock_httpx_client.assert_called_once()
         _, kwargs = mock_httpx_client.call_args
         self.assertEqual(kwargs["base_url"], "http://localhost:3000")
         self.assertFalse(kwargs["verify"])
         self.assertNotIn("X-API-KEY", kwargs["headers"])
+        mock_ssl_ctx_factory.assert_not_called()
 
     @patch("gvm.protocols.http.openvasd._client.Client")
-    def test_init_with_api_key_only(self, mock_httpx_client):
-        create_openvasd_http_client("localhost", api_key="secret")
+    @patch("gvm.protocols.http.openvasd._client.ssl.create_default_context")
+    def test_init_with_api_key_and_insecure_http(
+        self, mock_ssl_ctx_factory, mock_httpx_client
+    ):
+        create_openvasd_http_client(
+            "localhost", api_key="secret", insecure_http=True
+        )
         _, kwargs = mock_httpx_client.call_args
         self.assertEqual(kwargs["headers"]["X-API-KEY"], "secret")
         self.assertEqual(kwargs["base_url"], "http://localhost:3000")
         self.assertFalse(kwargs["verify"])
+        mock_ssl_ctx_factory.assert_not_called()
 
     @patch("gvm.protocols.http.openvasd._client.ssl.create_default_context")
     @patch("gvm.protocols.http.openvasd._client.Client")
@@ -72,3 +82,31 @@ class TestOpenvasdClient(unittest.TestCase):
         _, kwargs = mock_httpx_client.call_args
         self.assertEqual(kwargs["base_url"], "https://localhost:3000")
         self.assertEqual(kwargs["verify"], mock_context)
+
+    @patch("gvm.protocols.http.openvasd._client.ssl.create_default_context")
+    @patch("gvm.protocols.http.openvasd._client.Client")
+    def test_init_with_mtls_missing_cert(
+        self, mock_httpx_client, mock_ssl_ctx_factory
+    ):
+        with self.assertRaises(ValueError):
+            create_openvasd_http_client(
+                "localhost",
+                server_ca_path="/path/ca.pem",
+                client_cert_paths=None,
+            )
+        mock_httpx_client.assert_not_called()
+        mock_ssl_ctx_factory.assert_not_called()
+
+    @patch("gvm.protocols.http.openvasd._client.ssl.create_default_context")
+    @patch("gvm.protocols.http.openvasd._client.Client")
+    def test_init_with_mtls_missing_ca(
+        self, mock_httpx_client, mock_ssl_ctx_factory
+    ):
+        with self.assertRaises(ValueError):
+            create_openvasd_http_client(
+                "localhost",
+                server_ca_path=None,
+                client_cert_paths="/path/client.pem",
+            )
+        mock_httpx_client.assert_not_called()
+        mock_ssl_ctx_factory.assert_not_called()

--- a/tests/protocols/http/openvasd/test_client.py
+++ b/tests/protocols/http/openvasd/test_client.py
@@ -19,7 +19,6 @@ class TestOpenvasdClient(unittest.TestCase):
         mock_httpx_client.assert_called_once()
         _, kwargs = mock_httpx_client.call_args
         self.assertEqual(kwargs["base_url"], "http://localhost:3000")
-        self.assertFalse(kwargs["verify"])
         self.assertNotIn("X-API-KEY", kwargs["headers"])
         mock_ssl_ctx_factory.assert_not_called()
 
@@ -34,7 +33,6 @@ class TestOpenvasdClient(unittest.TestCase):
         _, kwargs = mock_httpx_client.call_args
         self.assertEqual(kwargs["headers"]["X-API-KEY"], "secret")
         self.assertEqual(kwargs["base_url"], "http://localhost:3000")
-        self.assertFalse(kwargs["verify"])
         mock_ssl_ctx_factory.assert_not_called()
 
     @patch("gvm.protocols.http.openvasd._client.ssl.create_default_context")

--- a/tests/protocols/http/openvasd/test_openvasd1.py
+++ b/tests/protocols/http/openvasd/test_openvasd1.py
@@ -28,6 +28,39 @@ class TestOpenvasdHttpApiV1(unittest.TestCase):
             api_key="test-key",
             server_ca_path="/path/to/ca.pem",
             client_cert_paths=("/path/to/client.pem", "/path/to/key.pem"),
+            insecure_http=False,
+        )
+
+        self.assertEqual(api._client, mock_httpx_client)
+        self.assertEqual(api.health._client, mock_httpx_client)
+        self.assertEqual(api.metadata._client, mock_httpx_client)
+        self.assertEqual(api.notus._client, mock_httpx_client)
+        self.assertEqual(api.scans._client, mock_httpx_client)
+        self.assertEqual(api.vts._client, mock_httpx_client)
+
+    @patch("gvm.protocols.http.openvasd._openvasd1.create_openvasd_http_client")
+    def test_initializes_all_sub_apis_insecure_http(
+        self, mock_crate_openvasd_client
+    ):
+        mock_httpx_client = MagicMock()
+        mock_crate_openvasd_client.return_value = mock_httpx_client
+
+        api = OpenvasdHttpAPIv1(
+            host_name="localhost",
+            port=3000,
+            api_key="test-key",
+            server_ca_path="/path/to/ca.pem",
+            client_cert_paths=("/path/to/client.pem", "/path/to/key.pem"),
+            insecure_http=True,
+        )
+
+        mock_crate_openvasd_client.assert_called_once_with(
+            host_name="localhost",
+            port=3000,
+            api_key="test-key",
+            server_ca_path="/path/to/ca.pem",
+            client_cert_paths=("/path/to/client.pem", "/path/to/key.pem"),
+            insecure_http=True,
         )
 
         self.assertEqual(api._client, mock_httpx_client)


### PR DESCRIPTION
## What
Set `mTLS` as default for `openvasd` library and only support HTTP when the flag `insecure_http` is explicitly set to true.

Missing TLS certificates will no longer fall back to HTTP. 

## Why
Be explicit about using insecure HTTP.
Resolve code scanning alerts.

## References
GEA-2017

