### PR TITLE
Add/get report exports

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -1826,7 +1826,7 @@ class GMPNext(GMPv227[T]):
 
     def get_report_export(
         self,
-        report_export_id: EntityID | None = None,
+        report_export_id: EntityID,
     ) -> T:
         """Request a single report export.
 

--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -26,6 +26,7 @@ from .requests.next import (
     ReportClosedCVEs,
     ReportCVEs,
     ReportErrors,
+    ReportExports,
     ReportHosts,
     ReportOperatingSystems,
     ReportPorts,
@@ -1806,5 +1807,27 @@ class GMPNext(GMPv227[T]):
                 notes_details=notes_details,
                 overrides_details=overrides_details,
                 result_tags=result_tags,
+            )
+        )
+
+    def get_report_exports(
+        self,
+        *,
+        report_export_id: EntityID | None = None,
+    ) -> T:
+        """Request report exports.
+
+        If report_export_id is provided, only the matching report export is
+        requested. Otherwise, the command requests a list of report exports.
+
+        Args:
+            report_export_id: UUID of an optional report export.
+
+        Returns:
+            A request for the get_report_exports GMP command.
+        """
+        return self._send_request_and_transform_response(
+            ReportExports.get_report_exports(
+                report_export_id=report_export_id,
             )
         )

--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -1812,22 +1812,32 @@ class GMPNext(GMPv227[T]):
 
     def get_report_exports(
         self,
-        *,
-        report_export_id: EntityID | None = None,
     ) -> T:
         """Request report exports.
 
-        If report_export_id is provided, only the matching report export is
-        requested. Otherwise, the command requests a list of report exports.
-
-        Args:
-            report_export_id: UUID of an optional report export.
+        The command requests a list of report exports.
 
         Returns:
             A request for the get_report_exports GMP command.
         """
         return self._send_request_and_transform_response(
-            ReportExports.get_report_exports(
+            ReportExports.get_report_exports()
+        )
+
+    def get_report_export(
+        self,
+        report_export_id: EntityID | None = None,
+    ) -> T:
+        """Request a single report export.
+
+        Args:
+            report_export_id: UUID of the report export.
+
+        Returns:
+            A request for the get_report_exports GMP command.
+        """
+        return self._send_request_and_transform_response(
+            ReportExports.get_report_export(
                 report_export_id=report_export_id,
             )
         )

--- a/gvm/protocols/gmp/requests/next/__init__.py
+++ b/gvm/protocols/gmp/requests/next/__init__.py
@@ -30,6 +30,9 @@ from gvm.protocols.gmp.requests.next._report_cves import (
 from gvm.protocols.gmp.requests.next._report_errors import (
     ReportErrors,
 )
+from gvm.protocols.gmp.requests.next._report_exports import (
+    ReportExports,
+)
 from gvm.protocols.gmp.requests.next._report_hosts import (
     ReportHosts,
 )
@@ -174,6 +177,7 @@ __all__ = (
     "ReportConfigParameter",
     "ReportConfigs",
     "ReportErrors",
+    "ReportExports",
     "ReportFormatType",
     "ReportFormats",
     "ReportHosts",

--- a/gvm/protocols/gmp/requests/next/_integration_configs.py
+++ b/gvm/protocols/gmp/requests/next/_integration_configs.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_report_applications.py
+++ b/gvm/protocols/gmp/requests/next/_report_applications.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_report_closed_cves.py
+++ b/gvm/protocols/gmp/requests/next/_report_closed_cves.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_report_cves.py
+++ b/gvm/protocols/gmp/requests/next/_report_cves.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_report_errors.py
+++ b/gvm/protocols/gmp/requests/next/_report_errors.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_report_exports.py
+++ b/gvm/protocols/gmp/requests/next/_report_exports.py
@@ -1,3 +1,8 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID
 from gvm.xml import XmlCommand
@@ -31,13 +36,20 @@ class ReportExports:
 
         Returns:
             A request for the get_report_exports GMP command.
-        """
-        cmd = XmlCommand("get_report_exports")
 
-        if report_export_id:
-            cmd.set_attribute(
-                "report_export_id",
-                str(report_export_id),
+        Raises:
+            RequiredArgument: If report_export_id is not provided.
+        """
+        if not report_export_id:
+            raise RequiredArgument(
+                function=cls.get_report_export.__name__,
+                argument="report_export_id",
             )
+
+        cmd = XmlCommand("get_report_exports")
+        cmd.set_attribute(
+            "report_export_id",
+            str(report_export_id),
+        )
 
         return cmd

--- a/gvm/protocols/gmp/requests/next/_report_exports.py
+++ b/gvm/protocols/gmp/requests/next/_report_exports.py
@@ -1,0 +1,32 @@
+from gvm.protocols.core import Request
+from gvm.protocols.gmp.requests import EntityID
+from gvm.xml import XmlCommand
+
+
+class ReportExports:
+    @classmethod
+    def get_report_exports(
+        cls,
+        *,
+        report_export_id: EntityID | None = None,
+    ) -> Request:
+        """Request report exports.
+
+        If report_export_id is provided, only the matching report export is
+        requested. Otherwise, the command requests a list of report exports.
+
+        Args:
+            report_export_id: UUID of an optional report export.
+
+        Returns:
+            A request for the get_report_exports GMP command.
+        """
+        cmd = XmlCommand("get_report_exports")
+
+        if report_export_id:
+            cmd.set_attribute(
+                "report_export_id",
+                str(report_export_id),
+            )
+
+        return cmd

--- a/gvm/protocols/gmp/requests/next/_report_exports.py
+++ b/gvm/protocols/gmp/requests/next/_report_exports.py
@@ -7,16 +7,27 @@ class ReportExports:
     @classmethod
     def get_report_exports(
         cls,
-        *,
-        report_export_id: EntityID | None = None,
     ) -> Request:
         """Request report exports.
 
-        If report_export_id is provided, only the matching report export is
-        requested. Otherwise, the command requests a list of report exports.
+        The command requests a list of report exports.
+
+        Returns:
+            A request for the get_report_exports GMP command.
+        """
+        cmd = XmlCommand("get_report_exports")
+
+        return cmd
+
+    @classmethod
+    def get_report_export(
+        cls,
+        report_export_id: EntityID,
+    ) -> Request:
+        """Request a single report export.
 
         Args:
-            report_export_id: UUID of an optional report export.
+            report_export_id: UUID of the report export.
 
         Returns:
             A request for the get_report_exports GMP command.

--- a/gvm/protocols/gmp/requests/next/_report_hosts.py
+++ b/gvm/protocols/gmp/requests/next/_report_hosts.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_report_operating_systems.py
+++ b/gvm/protocols/gmp/requests/next/_report_operating_systems.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_report_ports.py
+++ b/gvm/protocols/gmp/requests/next/_report_ports.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_report_tls_certificates.py
+++ b/gvm/protocols/gmp/requests/next/_report_tls_certificates.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_report_vulnerabilities.py
+++ b/gvm/protocols/gmp/requests/next/_report_vulnerabilities.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/gvm/protocols/gmp/requests/next/_scan_report.py
+++ b/gvm/protocols/gmp/requests/next/_scan_report.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
 from gvm.errors import RequiredArgument
 from gvm.protocols.core import Request
 from gvm.protocols.gmp.requests import EntityID

--- a/tests/protocols/gmpnext/entities/report_exports/__init__.py
+++ b/tests/protocols/gmpnext/entities/report_exports/__init__.py
@@ -2,8 +2,10 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 
+from .test_get_report_export import GmpGetReportExportTestMixin
 from .test_get_report_exports import GmpGetReportExportsTestMixin
 
 __all__ = [
+    "GmpGetReportExportTestMixin",
     "GmpGetReportExportsTestMixin",
 ]

--- a/tests/protocols/gmpnext/entities/report_exports/__init__.py
+++ b/tests/protocols/gmpnext/entities/report_exports/__init__.py
@@ -1,0 +1,9 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from .test_get_report_exports import GmpGetReportExportsTestMixin
+
+__all__ = [
+    "GmpGetReportExportsTestMixin",
+]

--- a/tests/protocols/gmpnext/entities/report_exports/test_get_report_export.py
+++ b/tests/protocols/gmpnext/entities/report_exports/test_get_report_export.py
@@ -2,13 +2,16 @@
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
+from gvm.errors import RequiredArgument
 
 
 class GmpGetReportExportTestMixin:
     def test_get_report_export_without_id(self):
-        self.gmp.get_report_export()
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_export(None)
 
-        self.connection.send.has_been_called_with(b"<get_report_exports/>")
+        with self.assertRaises(RequiredArgument):
+            self.gmp.get_report_export("")
 
     def test_get_report_export_with_id(self):
         self.gmp.get_report_export(report_export_id="e1")

--- a/tests/protocols/gmpnext/entities/report_exports/test_get_report_export.py
+++ b/tests/protocols/gmpnext/entities/report_exports/test_get_report_export.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+
+class GmpGetReportExportTestMixin:
+    def test_get_report_export_without_id(self):
+        self.gmp.get_report_export()
+
+        self.connection.send.has_been_called_with(b"<get_report_exports/>")
+
+    def test_get_report_export_with_id(self):
+        self.gmp.get_report_export(report_export_id="e1")
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_exports report_export_id="e1"/>'
+        )

--- a/tests/protocols/gmpnext/entities/report_exports/test_get_report_exports.py
+++ b/tests/protocols/gmpnext/entities/report_exports/test_get_report_exports.py
@@ -1,0 +1,18 @@
+# SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+
+class GmpGetReportExportsTestMixin:
+    def test_get_report_exports(self):
+        self.gmp.get_report_exports()
+
+        self.connection.send.has_been_called_with(b"<get_report_exports/>")
+
+    def test_get_report_exports_with_id(self):
+        self.gmp.get_report_exports(report_export_id="e1")
+
+        self.connection.send.has_been_called_with(
+            b'<get_report_exports report_export_id="e1"/>'
+        )

--- a/tests/protocols/gmpnext/entities/report_exports/test_get_report_exports.py
+++ b/tests/protocols/gmpnext/entities/report_exports/test_get_report_exports.py
@@ -9,10 +9,3 @@ class GmpGetReportExportsTestMixin:
         self.gmp.get_report_exports()
 
         self.connection.send.has_been_called_with(b"<get_report_exports/>")
-
-    def test_get_report_exports_with_id(self):
-        self.gmp.get_report_exports(report_export_id="e1")
-
-        self.connection.send.has_been_called_with(
-            b'<get_report_exports report_export_id="e1"/>'
-        )

--- a/tests/protocols/gmpnext/entities/test_report_exports.py
+++ b/tests/protocols/gmpnext/entities/test_report_exports.py
@@ -1,0 +1,13 @@
+#  SPDX-FileCopyrightText: 2026 Greenbone AG
+#
+#  SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from ...gmpnext import GMPTestCase
+from .report_exports import (
+    GmpGetReportExportsTestMixin,
+)
+
+
+class GmpGmpGetReportExportsTestCase(GmpGetReportExportsTestMixin, GMPTestCase):
+    pass

--- a/tests/protocols/gmpnext/entities/test_report_exports.py
+++ b/tests/protocols/gmpnext/entities/test_report_exports.py
@@ -6,8 +6,13 @@
 from ...gmpnext import GMPTestCase
 from .report_exports import (
     GmpGetReportExportsTestMixin,
+    GmpGetReportExportTestMixin,
 )
 
 
 class GmpGmpGetReportExportsTestCase(GmpGetReportExportsTestMixin, GMPTestCase):
+    pass
+
+
+class GmpGmpGetReportExportTestCase(GmpGetReportExportTestMixin, GMPTestCase):
     pass


### PR DESCRIPTION
## What

- Add `get_report_exports` request support
- Add tests for request generation

## Why

- Allow python-gvm clients to use the new `get_report_exports` GMP command

## References

GEA-2042

## Checklist

- [x] Tests


