### PR TITLE
add: support agent support bundle encryption

### DIFF
--- a/gvm/protocols/gmp/_gmpnext.py
+++ b/gvm/protocols/gmp/_gmpnext.py
@@ -314,6 +314,7 @@ class GMPNext(GMPv227[T]):
         self,
         agent_id: EntityID,
         days: int = 0,
+        encryption: bool = True,
     ) -> T:
         """Request a support bundle for an agent.
 
@@ -321,6 +322,7 @@ class GMPNext(GMPv227[T]):
             agent_id: ID of the agent to get the support bundle for.
             days: Number of days of logs to include. If None, zero is sent so the
                 Agent Controller uses its configured default.
+            encryption: Whether an encrypted or plain support bundle is requested.
 
         Raises:
             RequiredArgument: If agent_id is missing.
@@ -330,6 +332,7 @@ class GMPNext(GMPv227[T]):
             Agents.get_agent_support_bundle(
                 agent_id,
                 days=days,
+                encryption=encryption,
             )
         )
 

--- a/gvm/protocols/gmp/requests/next/_agents.py
+++ b/gvm/protocols/gmp/requests/next/_agents.py
@@ -438,6 +438,7 @@ class Agents:
         agent_id: EntityID,
         *,
         days: int = 0,
+        encryption: bool = True,
     ) -> Request:
         """Request a support bundle for an agent.
 
@@ -445,6 +446,7 @@ class Agents:
             agent_id: ID of the agent to get the support bundle for.
             days: Number of days of logs to include. If None, zero is sent so the
                 Agent Controller uses its configured default.
+            encryption: Whether an encrypted or plain support bundle is requested.
 
         Raises:
             RequiredArgument: If agent_id is missing.
@@ -462,5 +464,6 @@ class Agents:
         cmd = XmlCommand("get_agent_support_bundle")
         cmd.set_attribute("agent_uuid", str(agent_id))
         cmd.set_attribute("days", str(days))
+        cmd.set_attribute("encryption", to_bool(encryption))
 
         return cmd

--- a/tests/protocols/gmpnext/entities/agents/test_get_agent_support_bundle.py
+++ b/tests/protocols/gmpnext/entities/agents/test_get_agent_support_bundle.py
@@ -13,7 +13,7 @@ class GmpGetAgentSupportBundleTestMixin:
         )
 
         self.connection.send.has_been_called_with(
-            b'<get_agent_support_bundle agent_uuid="agent-123" days="7"/>'
+            b'<get_agent_support_bundle agent_uuid="agent-123" days="7" encryption="1"/>'
         )
 
     def test_get_agent_support_bundle_without_days_uses_zero(self):
@@ -22,7 +22,7 @@ class GmpGetAgentSupportBundleTestMixin:
         )
 
         self.connection.send.has_been_called_with(
-            b'<get_agent_support_bundle agent_uuid="agent-123" days="0"/>'
+            b'<get_agent_support_bundle agent_uuid="agent-123" days="0" encryption="1"/>'
         )
 
     def test_get_agent_support_bundle_with_zero_days(self):
@@ -32,7 +32,18 @@ class GmpGetAgentSupportBundleTestMixin:
         )
 
         self.connection.send.has_been_called_with(
-            b'<get_agent_support_bundle agent_uuid="agent-123" days="0"/>'
+            b'<get_agent_support_bundle agent_uuid="agent-123" days="0" encryption="1"/>'
+        )
+
+    def test_get_agent_support_bundle_with_zero_days_false_encryption(self):
+        self.gmp.get_agent_support_bundle(
+            agent_id="agent-123",
+            days=0,
+            encryption=False,
+        )
+
+        self.connection.send.has_been_called_with(
+            b'<get_agent_support_bundle agent_uuid="agent-123" days="0" encryption="0"/>'
         )
 
     def test_get_agent_support_bundle_without_agent_id(self):


### PR DESCRIPTION
## What

- Add the optional `encryption` parameter to `get_agent_support_bundle`.
- Default to encrypted support bundles when the parameter is not provided.
- Add tests for requesting encrypted and plain support bundles.

## Why

- Allow `python-gvm` clients to choose between encrypted and plain agent support bundles.
- Keep the existing encrypted behavior backward compatible.


## References

GEA-2040

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


